### PR TITLE
Fix Dependabot to enable updating Gems managed by GitHub Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
       prefix: 'build'
     target-branch: 'develop'
   - package-ecosystem: 'bundler'
+    registries:
+      - github-packages
     directory: '/'
     schedule:
       interval: 'daily'
@@ -36,3 +38,8 @@ updates:
     commit-message:
       prefix: 'build'
     target-branch: 'develop'
+registries:
+  github-packages:
+    type: rubygems-server
+    url: https://rubygems.pkg.github.com
+    token: ${{secrets.MY_GITHUB_TOKEN}}


### PR DESCRIPTION
## Description

I encountered an error with Dependabot where it was unable to authenticate with a private package registry, as shown in the image below. This error prevented updates to Gems from being applied.

<img width="1440" alt="スクリーンショット 2023-03-28 1 08 06" src="https://user-images.githubusercontent.com/80106172/228006886-930077d0-9b75-462c-ba1a-d7192df52310.png">

If this pull request is applied, the issue will be resolved by adding the registries section to the dependabot.yml file and creating a Dependabot secret named MY_GITHUB_TOKEN to store the GitHub token. This token will be used to authenticate with the private package registry.

## Reference

- [Configuration options for the dependabot.yml file](https://tinyurl.com/2fwwe3fj)
- [Configuring access to private registries for Dependabot](https://tinyurl.com/2omsdqgy)