### PR TITLE
chore: limit the MySQL version updated by Dependabot to v8.4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       timezone: 'Asia/Tokyo'
     reviewers:
       - 'P-manBrown'
+    ignore:
+      - dependency-name: 'mysql'
+        versions: ['>=8.5']
     commit-message:
       prefix: 'build'
     target-branch: 'main'


### PR DESCRIPTION
### Summary

To ensure the stability and security of the project by depending on LTS versions, the Dependabot configuration has been updated to limit MySQL updates to the LTS version v8.4.x.

### Changes

Added `ignore` values to the `dependabot.yml` configuration to exclude updates above v8.5.x.

### Testing

The following steps confirmed that Dependabot creates a pull request to update MySQL to v8.4.2:

1. Create a duplicate of the repository using the [GitHub Importer](https://docs.github.com/en/migrations/importing-source-code/using-github-importer/importing-a-repository-with-github-importer).
2. Apply the same changes to the `dependabot.yml` file on the `main` branch of the duplicate repository.
3. Verify that Dependabot creates a pull request to update MySQL from v8.0.33 to v8.4.2.

The pull request was successfully created as shown in the image below.

<img width="1243" alt="Screenshot 2024-08-02 19 03 57" src="https://github.com/user-attachments/assets/0002038b-08e0-4094-b798-41c26ff907c6">

### Related Issues (Optional)

Closes #73

### Notes (Optional)

None