### PR TITLE
chore: resolve errors when running rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development do
 
   gem "rubocop", "~> 1.48", require: false
   gem "rubocop-erb", "~> 0.5.2", require: false
+  gem "rubocop-factory_bot", "~> 2.26", require: false
   gem "rubocop-performance", "~> 1.21", require: false
   gem "rubocop-rails", "~> 2.25", require: false
   gem "rubocop-rspec", "~> 3.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,8 @@ GEM
     rubocop-erb (0.5.2)
       better_html
       rubocop (~> 1.45)
+    rubocop-factory_bot (2.26.1)
+      rubocop (~> 1.61)
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -447,6 +449,7 @@ DEPENDENCIES
   rspec-rails (~> 6.1)
   rubocop (~> 1.48)
   rubocop-erb (~> 0.5.2)
+  rubocop-factory_bot (~> 2.26)
   rubocop-performance (~> 1.21)
   rubocop-rails (~> 2.25)
   rubocop-rspec (~> 3.0)


### PR DESCRIPTION
### Summary

Add the missing Gem to resolve the error when running Rubocop.

### Changes

- Added `rubocop-factory_bot`
This change resolves the error that occurred when running Rubocop.

### Testing

- [x] Rubocop is functioning correctly
Confirmed that `bundle exec rubocop` runs successfully in the terminal.

### Related Issues (Optional)

None

### Notes (Optional)

Referenced the following page:
- [Upgrade to Version 3.x](https://docs.rubocop.org/rubocop-rspec/upgrade_to_version_3.html)
