### PR TITLE
chore: remove develop from Lefthook protect-branch

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,8 +16,8 @@ pre-commit:
       run: bin/bundle exec debride --rails -w debride-whitelist.txt {all_files} | tee /dev/tty | grep -q 'LOC:\ 0'
       fail_text: 'Read the report above.'
     protect-branch:
-      run: git branch --show-current | tee /dev/tty | grep -Eqvx 'main|develop'
-      fail_text: "ERROR: Do NOT commit directly to 'main' or 'develop' branch."
+      run: git branch --show-current | tee /dev/tty | grep -Eqvx 'main'
+      fail_text: "ERROR: Do NOT commit directly to 'main' branch."
 pre-push:
   commands:
     check-git-clean:


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Due to the change in branch strategy from Git Flow to GitHub Flow, the `develop` branch has been deleted.
However, there are still references to the `develop` branch in Lefthook `protect-branch`.
To improve code quality, we will remove the unnecessary references to the `develop` branch from Lefthook `protect-branch`.

### Changes

<!-- Explain the specific changes or additions made -->
- Removed `develop` from Lefthook `protect-branch`.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] References to the `develop` branch in Lefthook `protect-branch` have been removed.

- [x] Committing to the `main` branch causes an error with Lefthook.
Confirmed that committing to the `main` branch is not allowed by running `bundle exec lefthook run pre-commit` in the terminal.

<details>
  <summary>Execution Result</summary>

```shell
ruby ➜ ~/tascon-backend (main) $ bundle exec lefthook run pre-commit
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.7.11  hook: pre-commit │
╰───────────────────────────────────────╯
sync hooks: ✔️ (pre-commit, pre-push)
│  rubocop (skip) no files for inspection
│  htmlbeautifier (skip) no files for inspection
┃  protect-branch ❯ 

main

┃  debride ❯ 

These methods MIGHT not be called:

Total suspect LOC: 0

                                      
  ────────────────────────────────────
summary: (done in 0.65 seconds)       
✔️  debride
🥊  protect-branch: ERROR: Do NOT commit directly to 'main' branch.
```
</details>

- [x] Able to commit without errors on the `develop` branch.
Confirmed that committing to the `develop` branch is allowed by running `bundle exec lefthook run pre-commit` in the terminal.

<details>
  <summary>Execution Result</summary>

```shell
ruby ➜ ~/tascon-backend (develop) $ bundle exec lefthook run pre-commit
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.7.11  hook: pre-commit │
╰───────────────────────────────────────╯
│  htmlbeautifier (skip) no files for inspection
│  rubocop (skip) no files for inspection
┃  protect-branch ❯ 

develop

┃  debride ❯ 

These methods MIGHT not be called:

Total suspect LOC: 0

                                      
  ────────────────────────────────────
summary: (done in 0.60 seconds)       
✔️  protect-branch
✔️  debride
```
</details>

### Related Issues (Optional)

None

### Notes (Optional)

None
