### PR TITLE
chore: add 'reviewers' to '/Docker/web' in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
       interval: 'monthly'
       time: '03:00'
       timezone: 'Asia/Tokyo'
+    reviewers:
+      - 'P-manBrown'
     commit-message:
       prefix: 'build'
     target-branch: 'main'


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
To quickly respond to pull requests created by Dependabot, we add `reviewers` to `/Docker/web` in dependabot.yml.

### Changes

<!-- Explain the specific changes or additions made -->
- Add 'reviewers' to '/Docker/web' in dependabot.yml (31acffd19667e5255b8326d8448b05d546ee6b77)
This change ensures that I am set as the reviewer for pull requests that update the version of Nginx created by Dependabot.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] `reviewers` is added to `/Docker/web` in `dependabot.yml`.
[dependabot.yml](31acffd19667e5255b8326d8448b05d546ee6b77)

### Related Issues (Optional)

None

### Notes (Optional)

None

