### PR TITLE
fix: ensure confirmation email is sent correctly upon signing up

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -8,6 +8,6 @@
   <%= link_to t(".confirm_account_link"), confirmation_url(@resource, {
     confirmation_token: @token,
     config: message["client-config"].to_s,
-    redirect_url: message["rediret-url"].to_s,
-  }).html_safe # rubocop:disable Rails/OutputSafety %>
+    redirect_url: message["redirect-url"]
+  }) %>
 </p>


### PR DESCRIPTION
### Summary

An issue has occurred where an error occurs during sign-up and the confirmation email cannot be sent.
To resolve this, we will modify the content of `confirmation_instructions.html.erb`.

### Changes

- Made the following changes to `confirmation_instructions.html.erb`:
  - Removed comments to disable Rubocop
  - Removed stringification of `redirect_url`
  - Removed `.html_safe`

### Testing

- [x] The confirmation email is sent successfully when signing up.
I have verified that the confirmation email is sent successfully when signing up by running the application.
It is sent correctly as shown in the image below, and the links in the email also function properly.

<img width="1132" alt="スクリーンショット 2024-08-08 19 12 11" src="https://github.com/user-attachments/assets/737a8e02-eab5-492e-bcb2-47a7cea84deb">

<img width="1358" alt="スクリーンショット 2024-08-08 19 12 30" src="https://github.com/user-attachments/assets/63363e9d-d1e0-40b8-ab3d-b36eb62a4b58">

### Related Issues (Optional)

None

### Notes (Optional)

None
