### PR TITLE
fix: ensure password reset email is sent correctly

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -9,7 +9,7 @@
     reset_password_token: @token,
     config: message["client-config"].to_s,
     redirect_url: message["redirect-url"].to_s
-  }).html_safe # rubocop:disable Rails/OutputSafety %>
+  }) %>
 </p>
 <p><%= t(".ignore_mail_msg") %></p>
 <p><%= t(".no_changes_msg") %></p>


### PR DESCRIPTION
### Summary

There is an issue where an error occurs and the password reset email is not sent when a password reset request is made. To fix this, change the content of `reset_password_instructions.html.erb`.

### Changes

- Made the following changes to `reset_password_instructions.html.erb`:
  - Removed comments to disable Rubocop
  - Removed `.html_safe`

With these changes, the error that occurs during a password reset request is fixed and the password reset email is sent successfully.

### Testing

- [x] The password reset email is successfully sent when a password reset is requested.
Confirmed that the password reset email is successfully sent when a password reset is requested by operating the application. The email is sent correctly as shown in the attached images, and the links in the email also work correctly.

<img width="1171" alt="スクリーンショット 2024-08-09 10 49 14" src="https://github.com/user-attachments/assets/1e7b1e16-9473-43fb-a6df-c09842cb816c">

<img width="970" alt="スクリーンショット 2024-08-09 10 50 47" src="https://github.com/user-attachments/assets/a3c56884-4737-4d4b-bebd-82041c86b1de">

### Related Issues (Optional)

None

### Notes (Optional)

None
