### PR TITLE
refactor: review whether the monkey patch is still necessary

### DIFF
--- a/lib/monkey_patches/devise/omniauth_callbacks_controller_patch.rb
+++ b/lib/monkey_patches/devise/omniauth_callbacks_controller_patch.rb
@@ -4,7 +4,7 @@
 require "devise/version"
 require "devise_token_auth/version"
 raise "Consider removing this patch." unless Devise::VERSION == "4.9.4"
-raise "Consider removing this patch." unless DeviseTokenAuth::VERSION == "1.2.3"
+raise "Consider removing this patch." unless DeviseTokenAuth::VERSION == "1.2.4"
 
 Rails.application.config.to_prepare do
   Devise::OmniauthCallbacksController.class_eval do

--- a/lib/monkey_patches/devise_token_auth/application_controller_patch.rb
+++ b/lib/monkey_patches/devise_token_auth/application_controller_patch.rb
@@ -2,7 +2,7 @@
 #      see http://tinyurl.com/yla25xhq
 
 require "devise_token_auth/version"
-raise "Consider removing this patch." unless DeviseTokenAuth::VERSION == "1.2.3"
+raise "Consider removing this patch." unless DeviseTokenAuth::VERSION == "1.2.4"
 
 Rails.application.config.to_prepare do
   DeviseTokenAuth::ApplicationController.class_eval do


### PR DESCRIPTION
### Summary

I re-evaluated the necessity of the monkey patches.
As a result, there were no unnecessary monkey patches, so I will update the versions of Devise and DeviseTokenAuth listed in the monkey patch files.

### Changes

- Update Devise and DeviseTokenAuth versions in monkey patch files

### Testing

- [x] Unnecessary monkey patches have been removed.
There were no unnecessary monkey patches.

- [x] The versions of the gems listed in the monkey patch files have been updated to the current versions.
- [x] The server starts up normally.
Confirmed that the server starts up normally with `bundle exec puma -C config/puma.rb` in the terminal.

### Related Issues (Optional)

None

### Notes (Optional)

None
