### PR TITLE
feat: modify to not set the current_user_id cookie during authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::API
   # Avoid making the response headers too large.
   after_action :delete_user_session
   after_action :delete_csrf_token, only: :destroy, if: :devise_controller?
-  after_action :delete_current_user_id, only: :destroy, if: :devise_controller?
 
   include ActionController::Cookies
   include ActionController::RequestForgeryProtection
@@ -19,10 +18,6 @@ class ApplicationController < ActionController::API
     def delete_csrf_token
       session.delete(:_csrf_token)
       cookies.delete(:csrf_token)
-    end
-
-    def delete_current_user_id
-      cookies.delete(:current_user_id)
     end
 
     def render_error(status, message)

--- a/app/controllers/concerns/set_user_by_token_override.rb
+++ b/app/controllers/concerns/set_user_by_token_override.rb
@@ -12,11 +12,6 @@ module SetUserByTokenOverride
         value: auth_header.to_json,
         expires:
       )
-
-      cookies[:current_user_id] = DeviseTokenAuth.cookie_attributes.merge(
-        value: current_api_v1_user.id,
-        expires:
-      )
     end
   # rubocop:enable Naming/AccessorMethodName
 end


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The `current_user_id` cookie is no longer used on the client side.
To improve maintainability, the code that sets the `current_user_id` cookie during authentication has been removed.

### Changes

<!-- Explain the specific changes or additions made -->
- Removed `current_user_id` handling from the application controller and token override.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [ ] The `current_user_id` cookie is not set during authentication.
Confirmed that the `Set-Cookie` header in the login response does not contain `current_user_id`.

- before
<img width="1552" alt="スクリーンショット 2024-11-01 11 22 00" src="https://github.com/user-attachments/assets/ad706005-e90b-4fca-b4d3-cd034c395806">

- after
<img width="1552" alt="スクリーンショット 2024-11-01 11 24 16" src="https://github.com/user-attachments/assets/86dde3a6-151c-4558-bd94-7f397b9d453b">

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
