### PR TITLE
feat: delete authentication cookies when an account is deleted

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -19,6 +19,14 @@ module Api
           super
         end
 
+        def destroy
+          super do
+            if DeviseTokenAuth.cookie_enabled
+              cookies.delete(DeviseTokenAuth.cookie_name, domain: DeviseTokenAuth.cookie_attributes[:domain])
+            end
+          end
+        end
+
         private
           def should_set_redirect_url?
             new_email = account_update_params[:email]


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The authentication cookie (`auth_cookie`) is not deleted when an account is deleted.
To align with the logout process, the authentication cookie will now be deleted when an account is deleted.

### Changes

<!-- Explain the specific changes or additions made -->
- Add cookie deletion on user account destruction

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The authentication cookie (`auth_cookie`) is deleted when an account is deleted.
As shown in the image below, it was confirmed that the `auth_cookie` is deleted when an account is deleted.

<img width="1552" alt="スクリーンショット 2024-11-01 17 15 08" src="https://github.com/user-attachments/assets/7ab5c38d-9e46-4def-b9c1-439c0480ed44">

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
