### PR TITLE
chore: resolve errors when building Docker containers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.5"
+ruby "3.3.6"
 
 gem "rails", "~> 7.2.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 3.3.5p100
+   ruby 3.3.6p108
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
### Summary

Fix the Ruby version in the `Gemfile` to resolve the error that occurs when running `devcontainer build` in the terminal.

### Changes

- Change the Ruby version in the `Gemfile` to v3.3.6.
This change resolves the error that occurs when running `devcontainer build` and allows the Docker container to start successfully.

### Testing

- [x] Docker container builds successfully.
Confirmed that the build completes successfully by running `devcontainer build` in the terminal.

### Related Issues (Optional)

None

### Notes (Optional)

None
