### PR TITLE
feat!: change the timing of authentication in the password reset process

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -10,6 +10,7 @@ DeviseTokenAuth.setup do |config|
   config.check_current_password_before_update = :password
 
   config.remove_tokens_after_password_reset = true
+  config.require_client_password_reset_token = true
 
   config.omniauth_prefix = "/api/v1/omniauth"
 end


### PR DESCRIPTION

### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, the password reset process follows the following flow:

1. Enter email address on the password reset screen.
2. Send confirmation email to the entered email address.
3. User clicks on the link in the confirmation email.
4. Redirect to the password change screen after authentication.
5. Change the password.

With the above flow, users can continue using the application without changing their password.
This may result in a long period where password reset is possible without entering the current password.
To improve security, the password reset process is changed to authenticate after password change..

### Changing

<!-- Explain the specific changes or additions made -->

- Change Devise Token Auth settings to authenticate after password change.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
I have verified that the user is authenticated after the password reset process using Postman as shown in the image below.

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issues) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
