### PR TITLE
chore: change dependabot update schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/Docker/api'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
     reviewers:
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/Docker/db'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
     reviewers:
@@ -28,7 +28,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/Docker/web'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
     reviewers:
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: 'bundler'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
     reviewers:


### PR DESCRIPTION
### Summary

This pull request updates the schedule for Dependabot to check for updates daily instead of monthly. This change aims to ensure that our dependencies are kept up-to-date more frequently, enhancing the security and stability of the project.

### Changes

- Modified the Dependabot configuration to set the update schedule to daily for all specified package ecosystems.

### Testing

The changes were tested by reviewing the updated configuration file to ensure that the schedule is correctly set to daily.

### Related Issues (Optional)

None

### Notes (Optional)

None