### PR TITLE
refactor: clean up compose.yml configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,4 @@
-x-mysql_env_path: &mysql-env-path
-  ./Docker/db/environment/mysql.env
+x-mysql_env_path: &mysql-env-path ./Docker/db/environment/mysql.env
 
 services:
   db:
@@ -24,12 +23,10 @@ services:
         - USER_NAME=${API_USER_NAME:?}
     volumes:
       - .:/home/${API_USER_NAME:?}/${COMPOSE_PROJECT_NAME:?}
-      - ./.git-lint.yml:/home/${API_USER_NAME:?}/.xdg/git-lint/configuration.yml
       - gem-home:/usr/local/bundle
       - puma-sockets:/home/${API_USER_NAME}/${COMPOSE_PROJECT_NAME}/tmp/sockets
     environment:
       - RAILS_ENV=${RAILS_ENV:-development}
-      - XDG_CONFIG_DIRS=/home/${API_USER_NAME:?}/.xdg
     env_file:
       - *mysql-env-path
     extra_hosts:


### PR DESCRIPTION
### Summary

Remove unnecessary descriptions related to git-lint from `compose.yml`, since git-lint is no longer used.

### Changes

- Removed unnecessary volume  of `git-lint`.
- Removed `XDG_CONFIG_DIRS`.

### Testing

Run the updated `compose.yml` file to verify that the application starts correctly. Verified that all services are functioning as expected.

### Related issues (optional)

None

### Notes (optional)

None