### PR TITLE
feat: add display name and note to contacts

### DIFF
--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       private
         def contact_params
-          params.require(:contact).permit(:contact_user_id)
+          params.require(:contact).permit(:contact_user_id, :display_name, :note)
         end
     end
   end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,6 +3,8 @@ class Contact < ApplicationRecord
   belongs_to :contact_user, class_name: "User"
 
   validates :contact_user_id, uniqueness: { scope: :user_id }
+  validates :display_name, presence: true, allow_nil: true
+  validates :note, presence: true, allow_nil: true
   validate :not_self_contact, :contact_user_must_be_public
 
   def not_self_contact

--- a/app/resources/contact_resource.rb
+++ b/app/resources/contact_resource.rb
@@ -1,7 +1,7 @@
 class ContactResource < ApplicationResource
   root_key :contact, :contacts
 
-  attributes id: [String, true]
+  attributes id: [String, true], display_name: [String, true], note: [String, true]
 
   one :contact_user, resource: UserResource
 end

--- a/config/locales/active_record.ja.yml
+++ b/config/locales/active_record.ja.yml
@@ -27,5 +27,7 @@ ja:
       contact:
         contact_user: "対象ユーザー"
         contact_user_id: "対象ユーザーID"
+        display_name: "表示名"
+        note: "メモ"
     models:
       user: "ユーザー"

--- a/db/migrate/20250119101340_add_display_name_and_note_to_contacts.rb
+++ b/db/migrate/20250119101340_add_display_name_and_note_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddDisplayNameAndNoteToContacts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contacts, :display_name, :string
+    add_column :contacts, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_17_143501) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_19_101340) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_ja_0900_as_cs", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -44,6 +44,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_17_143501) do
     t.bigint "contact_user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "display_name"
+    t.text "note"
     t.index ["contact_user_id"], name: "index_contacts_on_contact_user_id"
     t.index ["user_id", "contact_user_id"], name: "index_contacts_on_user_id_and_contact_user_id", unique: true
     t.index ["user_id"], name: "index_contacts_on_user_id"


### PR DESCRIPTION
### Summary

This pull request introduces enhancements to the contact management system by adding `display_name` and `note` attributes to the contacts. These changes aim to improve the user experience by allowing users to store and additional information about their contacts.

### Changes

- Added `display_name` and `note` columns to the `contacts` table, updating the schema version to reflect the new migration.
- Updated the `contact_params` method to permit `display_name` and `note` attributes, enabling the API to handle these new fields.
- Implemented presence validation for `display_name` and `note` attributes in the Contact model to ensure data integrity.
- Enhanced the ContactResource to include `display_name` and `note` attributes, allowing these values to be returned in API responses.
- Added translations for "display_name" and "note" in the Japanese locale file to improve the user interface for Japanese-speaking users.

### Testing

Verified to work properly using Postman as shown in the following image.
- Can be saved
<img width="1215" alt="スクリーンショット 2025-01-19 23 08 53" src="https://github.com/user-attachments/assets/a3c6e6c7-b4e9-44d7-8d6e-186ff9c8bed9" />

- Empty characters cannot be registered
<img width="1218" alt="スクリーンショット 2025-01-19 23 10 27" src="https://github.com/user-attachments/assets/eefdc653-80f5-4351-a435-1b55001e4940" />

- Only spaces cannot be registered
<img width="1216" alt="スクリーンショット 2025-01-19 23 12 15" src="https://github.com/user-attachments/assets/07e5f1c9-a60c-44af-87d6-14971112b9b3" />

- Can register null
<img width="1217" alt="スクリーンショット 2025-01-19 23 12 50" src="https://github.com/user-attachments/assets/15198701-d42d-49bd-9652-2d6907cbe3e8" />


### Related Issues (Optional)

N/A

### Notes (Optional)

N/A