### PR TITLE
feat: change to allow null in user's bio

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: { case_sensitive: false }, length: { maximum: 100 }
   validates :avatar, content_type: { in: %w[image/jpeg image/png] }, size: { less_than_or_equal_to: 2.megabytes },
                      processable_image: true, mime_type_and_extension_consistency: true
-  validates :bio, length: { maximum: 250 }
+  validates :bio, length: { maximum: 250 }, presence: true, allow_nil: true
 
   def avatar=(value)
     if value.respond_to?(:original_filename) && value.original_filename

--- a/db/migrate/20250120040935_remove_constraints_from_users_bio.rb
+++ b/db/migrate/20250120040935_remove_constraints_from_users_bio.rb
@@ -1,0 +1,5 @@
+class RemoveConstraintsFromUsersBio < ActiveRecord::Migration[8.0]
+  def change
+    change_column :users, :bio, :string, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_19_101340) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_20_040935) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_ja_0900_as_cs", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -69,7 +69,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_19_101340) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_private", default: true, null: false
-    t.string "bio", default: "", null: false
+    t.string "bio"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
### Summary

This pull request introduces updates to the user bio validations and schema, enhancing the flexibility and integrity of user data.

### Changes

- Removed constraints from the users' bio column in the database, allowing null values and eliminating the default value. This change enables users to have an empty bio without being forced to provide a default.
- Added a presence validation for the bio attribute in the User model. This ensures that while the bio can be nil, it is validated for presence when provided, improving data integrity.

### Testing

I confirmed that the changes work as expected using Postman:
- Success
<img width="1216" alt="スクリーンショット 2025-01-20 13 25 12" src="https://github.com/user-attachments/assets/7a06b62d-5584-4765-a503-152f9ee140fb" />

- Empty string
<img width="1218" alt="スクリーンショット 2025-01-20 13 24 32" src="https://github.com/user-attachments/assets/cef1366e-b650-4ae2-b857-60595d611b22" />

- Only spaces
<img width="1216" alt="スクリーンショット 2025-01-20 13 24 49" src="https://github.com/user-attachments/assets/bbefeeb7-c505-488a-9bfc-bf21cd269eb8" />

### Related Issues (Optional)

N/A

### Notes (Optional)

I decided to remove the NOT NULL constraint from the bio based on the following page.
- <https://qiita.com/daichi_yamazaki/items/ea3516080948e95bbf26>