### PR TITLE
build: remove typelizer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,4 @@ group :development do
   gem "rubocop-performance", "~> 1.23", require: false
   gem "rubocop-rails", "~> 2.29", require: false
   gem "rubocop-rspec", "~> 3.4", require: false
-
-  gem "typelizer", "~> 0.2.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,8 +408,6 @@ GEM
     strscan (3.1.0)
     thor (1.3.2)
     timeout (0.4.3)
-    typelizer (0.2.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
@@ -464,7 +462,6 @@ DEPENDENCIES
   rubocop-performance (~> 1.23)
   rubocop-rails (~> 2.29)
   rubocop-rspec (~> 3.4)
-  typelizer (~> 0.2.0)
   tzinfo-data
 
 RUBY VERSION

--- a/app/resources/application_resource.rb
+++ b/app/resources/application_resource.rb
@@ -1,4 +1,3 @@
 class ApplicationResource
   include Alba::Resource
-  include Typelizer::DSL
 end

--- a/app/resources/error_resource.rb
+++ b/app/resources/error_resource.rb
@@ -2,6 +2,4 @@ class ErrorResource < ApplicationResource
   root_key :error, :errors
 
   attributes :attribute, :full_message
-
-  typelize attribute: :string, full_message: :string
 end

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -2,6 +2,4 @@ class UserResource < ApplicationResource
   root_key :user, :users
 
   attributes :id, :name, :bio, :avatar_url
-
-  typelize avatar_url: [:string, { nullable: true }]
 end

--- a/config/initializers/typelizer.rb
+++ b/config/initializers/typelizer.rb
@@ -1,3 +1,0 @@
-Typelizer.configure do |config|
-  config.output_dir = Rails.root.join("tmp/typelizer")
-end


### PR DESCRIPTION
### Summary

This pull request aims to remove the Typelizer gem from the project to prevent errors during the execution of `rails db:setup`.

### Changes

- The Typelizer gem has been removed from both the Gemfile and Gemfile.lock.
- Integration points related to Typelizer have been refactored to ensure the application functions correctly without it.

### Testing

The changes were tested by running `rails db:setup` to confirm that no errors occur after the removal of the Typelizer gem. Additionally, the application was run to ensure that all functionalities remain intact without the Typelizer integration.

### Related Issues (Optional)

N/A

### Notes (Optional)

This change is part of an effort to streamline the build process and eliminate unnecessary dependencies that may cause issues during setup.