### PR TITLE
feat: include the current user's contact info in the user's details

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,9 +2,9 @@ module Api
   module V1
     class UsersController < ApplicationController
       def show
-        user = User.find(params[:id])
+        @user = User.find(params[:id])
 
-        render json: UserResource.new(user), status: :ok
+        render json: UserResource.new(@user, params: { current_user_contact: }), status: :ok
       end
 
       def search
@@ -16,6 +16,11 @@ module Api
           render json: UserResource.new(user), status: :ok
         end
       end
+
+      private
+        def current_user_contact
+          current_api_v1_user.contacts.find_by(contact_user_id: @user.id)
+        end
     end
   end
 end

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -2,4 +2,8 @@ class UserResource < ApplicationResource
   root_key :user, :users
 
   attributes :id, :name, :bio, :avatar_url
+
+  attribute :current_user_contact, if: proc { !params[:current_user_contact].nil? } do
+    ContactResource.new(params[:current_user_contact], within: :user).to_h
+  end
 end


### PR DESCRIPTION
### Summary

This pull request introduces the functionality to include the current user's contact information in the user's details response. This allows the client to retrieve the contact information that the current user has registered for a specific user.

### Changes

- Modified the `show` action in `UsersController` to set the user instance variable and include the current user's contact information in the response.
- Introduced a method to retrieve the current user's registered contact information for the specified user.
- Updated the `UserResource` to conditionally include the current user's contact in the serialized response.

### Testing

Confirmed that the changes work as expected, as shown in the images below:
- When contact information is registered
- When no contact information is registered

### Related Issues (Optional)

N/A

### Notes (Optional)

The current implementation of `current_user_contact` in `UserResource` does not support returning multiple user information. If there is a need to return multiple user information, the implementation will need to be modified.