### PR TITLE
feat: include current user contact in user search results

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,12 +8,12 @@ module Api
       end
 
       def search
-        user = User.find_by(email: params[:email], is_private: false)
+        @user = User.find_by(email: params[:email], is_private: false)
 
-        if user.nil?
+        if @user.nil?
           render json: { user: nil }, status: :ok
         else
-          render json: UserResource.new(user), status: :ok
+          render json: UserResource.new(@user, params: { current_user_contact: }), status: :ok
         end
       end
 


### PR DESCRIPTION
### Summary

This pull request introduces a feature that includes the current user's contact information in the user search results. With this change, clients will be able to retrieve the contact information registered by the current user during user searches.

### Changes

- Updated the rendering of the user resource to include the current user contact parameter in the search results.

### Testing

I have confirmed that the changes work as expected, as shown in the images below:
- When the contact is registered
  <img width="1412" alt="スクリーンショット 2025-01-26 23 31 15" src="https://github.com/user-attachments/assets/1f47169d-baa0-4bee-a320-1337c7f55f15" />

- When the contact is not registered
  <img width="1413" alt="スクリーンショット 2025-01-26 23 36 30" src="https://github.com/user-attachments/assets/bfd44d64-24e2-43df-8fa2-4cc92d5d28c4" />


### Related Issues (Optional)

N/A

### Notes (Optional)

N/A