### PR TITLE
chore: update avatar validation to processable_file

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, uniqueness: { case_sensitive: false }, length: { maximum: 100 }
   validates :avatar, content_type: { in: %w[image/jpeg image/png] }, size: { less_than_or_equal_to: 2.megabytes },
-                     processable_image: true, mime_type_and_extension_consistency: true
+                     processable_file: true, mime_type_and_extension_consistency: true
   validates :bio, length: { maximum: 250 }, presence: true, allow_nil: true
 
   def avatar=(value)

--- a/config/locales/active_storage_validations.ja.yml
+++ b/config/locales/active_storage_validations.ja.yml
@@ -4,4 +4,4 @@ ja:
     messages:
       content_type_invalid: "には%{authorized_types}のファイルを選択してください。"
       file_size_out_of_range: "には%{max_size}以下のファイルを選択してください。"
-      image_not_processable: "にできない不正な画像です。"
+      file_not_processable: "にできない不正なファイルです。"


### PR DESCRIPTION
### Summary

This pull request updates the avatar validation method to ensure compatibility with version 2.0.0 of the `active_storage_validations` gem.

### Changes

- Changed the avatar validation from `processable_image` to `processable_file` to align with the new requirements introduced in the latest version of the gem.
- Modified `config/locales/active_storage_validations.ja.yml` to change the error message for `processable_file` to "にできない不正なファイルです。"

### Testing

Confirmed that the expected error is returned as shown in the following image .
<img width="1214" alt="スクリーンショット 2025-01-28 17 00 16" src="https://github.com/user-attachments/assets/5d2c9941-eee9-462a-9318-78f0d2d81d93" />

### Related Issues (Optional)

N/A

### Notes (Optional)

N/A