### PR TITLE
chore: update debride whitelist

### DIFF
--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -26,3 +26,4 @@ render_data
 resource_update_method
 search
 contact_users
+current_user_contact


### PR DESCRIPTION
### Summary

This pull request updates the debride whitelist to include a new entry for `current_user_contact`. This change aims to prevent incorrect errors from occurring due to debride.

### Changes

- Added `current_user_contact` to the debride whitelist.

### Testing

I ran `bundle exec debride --rails -w debride-whitelist.txt .` to confirm that no errors occurred.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.