### PR TITLE
feat!: update contact creation response Location header

### DIFF
--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       private
         def contact_params
-          params.require(:contact).permit(:contact_user_id, :display_name, :note)
+          params.expect(contact: %i[contact_user_id display_name note])
         end
     end
   end

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -5,7 +5,7 @@ module Api
         contact = current_api_v1_user.contacts.build(contact_params)
 
         if contact.save
-          render json: ContactResource.new(contact), status: :created, location: api_v1_contact_url(contact)
+          render json: ContactResource.new(contact), status: :created, location: api_v1_user_url(contact.contact_user)
         else
           render json: ErrorResource.new(contact.errors), status: :unprocessable_entity
         end


### PR DESCRIPTION
### Summary

This pull request modifies the Location header returned during contact creation to point to an endpoint that retrieves details of the target user. This change is made because the contact details are returned alongside the user details.

### Changes

- Refactored the `contact_params` method to use `params.expect` instead of `permit`. This change ensures that only the specified keys are allowed aligning with best practices introduced in Rails v8.0.
- Updated the response for contact creation to change the Location header. The new header now points to the associated user rather than the contact itself.

### Testing

Confirmed that the Location header has been updated as shown in the following image.
<img width="1416" alt="スクリーンショット 2025-01-28 19 45 13" src="https://github.com/user-attachments/assets/88f6d1b6-2e98-495b-9c11-b3f4931c7145" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.