### PR TITLE
refactor: restrict self-contact validation to creation

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,7 +5,7 @@ class Contact < ApplicationRecord
   validates :contact_user_id, uniqueness: { scope: :user_id }
   validates :display_name, presence: true, allow_nil: true
   validates :note, presence: true, allow_nil: true
-  validate :not_self_contact
+  validate :not_self_contact, on: :create
   validate :contact_user_must_be_public
 
   def not_self_contact


### PR DESCRIPTION
### Summary

This pull request introduces a refactor that restricts the self-contact validation to only occur during the creation of a contac. This change ensures that existing contacts can be updated without triggering these validations unnecessarily.

### Changes

- Modified the self-contact validation logic to ensure it is only applied when a new contact is being created.

### Testing

The changes were tested by creating new contacts to verify that the self-contact validation is triggered as expected. Additionally, existing contacts were updated to ensure that the validation does not interfere with the update process.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.