### PR TITLE
refactor: restrict contact_user_must_be_public validation to creation

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -6,7 +6,7 @@ class Contact < ApplicationRecord
   validates :display_name, presence: true, allow_nil: true
   validates :note, presence: true, allow_nil: true
   validate :not_self_contact, on: :create
-  validate :contact_user_must_be_public
+  validate :contact_user_must_be_public, on: :create
 
   def not_self_contact
     return unless user_id == contact_user_id


### PR DESCRIPTION
### Summary

This pull request refactors the validation logic for `contact_user_must_be_public` to ensure that it is only enforced during the creation of a contact user. This change aims to streamline the validation process by removing unnecessary checks during update actions.

### Changes

- Modified the `contact_must_be` validation to trigger on create operations rather than on both create and. This adjustment the validation flow and reduces overhead during updates.

### Testing

The changes were tested by creating new contact users to verify that the validation is correctly enforced. Additionally, existing contact users were updated to ensure that the validation does not interfere with the update process, confirming that the system behaves as expected without unnecessary validation errors.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.