### PR TITLE
feat: add contacts list feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "devise_token_auth", "~> 1.2"
 gem "omniauth-google-oauth2"
 gem "omniauth-twitter", "~> 1.4"
 
+gem "pagy", "~> 9.3"
+
 gem "rails-i18n", "~> 8.0"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
       rack
     orm_adapter (0.5.0)
     ostruct (0.6.1)
+    pagy (9.3.3)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -451,6 +452,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   omniauth-google-oauth2
   omniauth-twitter (~> 1.4)
+  pagy (~> 9.3)
   puma (~> 6.5)
   rack-cors (~> 2.0)
   rails (~> 8.0.1)

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -3,6 +3,13 @@ module Api
     class ContactsController < ApplicationController
       before_action :set_contact, only: %i[update destroy]
 
+      def index
+        user_contacts = current_api_v1_user.contacts.includes(contact_user: :avatar_attachment).order(:created_at)
+        @pagy, contacts = pagy(user_contacts, items: 20)
+
+        render json: ContactResource.new(contacts), status: :ok
+      end
+
       def create
         @contact = current_api_v1_user.contacts.build(create_contact_params)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,10 @@ class ApplicationController < ActionController::API
   before_action :authenticate_api_v1_user!, unless: :devise_controller?
   # Avoid making the response headers too large.
   after_action :delete_user_session
+  after_action :merge_pagy_headers, if: -> { @pagy.present? }
 
   include DeviseTokenAuth::Concerns::SetUserByToken
+  include Pagy::Backend
 
   private
     def delete_user_session
@@ -15,5 +17,9 @@ class ApplicationController < ActionController::API
       return if request.get? || request.head? || request.origin == ENV.fetch("FRONTEND_ORIGIN")
 
       raise ActionController::BadRequest
+    end
+
+    def merge_pagy_headers
+      pagy_headers_merge(@pagy)
     end
 end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (9.3.3)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+# Here are the few that make more sense as DEFAULTs:
+# Pagy::DEFAULT[:limit]       = 20                    # default
+# Pagy::DEFAULT[:size]        = 7                     # default
+# Pagy::DEFAULT[:ends]        = true                  # default
+# Pagy::DEFAULT[:page_param]  = :page                 # default
+# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
+# Pagy::DEFAULT[:max_pages]   = 3000                  # example
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+# Legacy Compatibility Extras
+
+# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
+# See https://ddnexus.github.io/pagy/docs/extras/size
+# require 'pagy/extras/size'   # must be required before the other extras
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each calendar unit class in IRB:
+# >> Pagy::Calendar::Year::DEFAULT
+# >> Pagy::Calendar::Quarter::DEFAULT
+# >> Pagy::Calendar::Month::DEFAULT
+# >> Pagy::Calendar::Week::DEFAULT
+# >> Pagy::Calendar::Day::DEFAULT
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See https://ddnexus.github.io/pagy/docs/extras/headers
+require "pagy/extras/headers"
+Pagy::DEFAULT[:headers] = { page: "Current-Page",
+                            limit: "Page-Items",
+                            count: "Total-Count",
+                            pages: "Total-Pages" } # default
+
+# Keyset extra: Paginate with the Pagy keyset pagination technique
+# See https://ddnexus.github.io/pagy/docs/extras/keyset
+# require 'pagy/extras/keyset'
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/js_tools'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Pagy extra: Add the pagy styled versions of the javascript-powered navs
+# and a few other components to the Pagy::Frontend module.
+# See https://ddnexus.github.io/pagy/docs/extras/pagy
+# require 'pagy/extras/pagy'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
+# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the limit per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
+
+# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/limit
+# require 'pagy/extras/limit'
+# set to false only if you want to make :limit_extra an opt-in variable
+# Pagy::DEFAULT[:limit_extra] = false    # default true
+# Pagy::DEFAULT[:limit_param] = :limit   # default
+# Pagy::DEFAULT[:limit_max]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+require "pagy/extras/overflow"
+Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Jsonapi extra: Implements JSON:API specifications
+# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
+# require 'pagy/extras/jsonapi'   # must be required after the other extras
+# set to false only if you want to make :jsonapi an opt-in variable
+# Pagy::DEFAULT[:jsonapi] = false  # default true
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,8 +22,8 @@ User.create!(
   bio: "テスト用のユーザー",
   confirmed_at: Time.current
 )
-# Create 20 users.
-20.times do
+# Create 100 users.
+100.times do
   password = Faker::Alphanumeric.alphanumeric(number: 10)
 
   User.create!(
@@ -35,4 +35,20 @@ User.create!(
     bio: Faker::Lorem.paragraph(sentence_count: 10),
     confirmed_at: Time.current
   )
+end
+
+# Delete all contacts.
+Contact.destroy_all
+# Create contacts for test user.
+test_user = User.find_by(email: "test@example.com")
+other_users = User.where.not(id: test_user.id)
+other_users.each do |contact_user|
+  Contact.create!(
+    user_id: test_user.id,
+    contact_user_id: contact_user.id,
+    display_name: Faker::Name.name,
+    note: Faker::Lorem.paragraph(sentence_count: 3)
+  )
+rescue ActiveRecord::RecordInvalid
+  next
 end


### PR DESCRIPTION
### Summary

This pull request introduces a new feature that allows users to view a list of contacts. It enhances the user experience by implementing pagination using the Pagy gem, ensuring that the contacts are displayed efficiently without overwhelming the user with too much information at once.

### Changes

- Added the Pagy gem to the application for pagination functionality.
- Added the index action to the `ContactsController` to enable retrieval of the contacts list.
- Integrated pagination in the contacts index action to limit the number of contacts displayed at one time.
- Updated seed data to increase the number of users created from 20 to 100 for more comprehensive testing, and added logic to delete existing contacts and create new contacts for the test user.

### Testing

I confirmed that the list is retrieved as shown in the images, and that appropriate headers are applied.

<img width="1416" alt="スクリーンショット 2025-02-01 16 06 50" src="https://github.com/user-attachments/assets/4f93a433-c16e-4df7-87a2-17c4041df35e" />

Also I confirmed that an empty array is returned if the contact to be returned does not exist.

<img width="1416" alt="スクリーンショット 2025-02-01 15 53 58" src="https://github.com/user-attachments/assets/f5d0c571-9172-4ded-bffb-b0861dcd62bf" />


### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.