### PR TITLE
feat: add length validation for display name

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,7 +3,7 @@ class Contact < ApplicationRecord
   belongs_to :contact_user, class_name: "User"
 
   validates :contact_user_id, uniqueness: { scope: :user_id }
-  validates :display_name, presence: true, allow_nil: true
+  validates :display_name, presence: true, allow_nil: true, length: { maximum: 255 }
   validates :note, presence: true, allow_nil: true
   validate :not_self_contact, on: :create
   validate :contact_user_must_be_public, on: :create


### PR DESCRIPTION
### Summary

This pull request introduces a new feature that adds length validation for display names. The primary goal is to enhance data integrity by ensuring that display names do not exceed a specified character limit.

### Changes

- Implemented validation logic to restrict display names to a maximum of 255 characters. This change improves data integrity and prevents potential issues with overly long names.

### Testing

I have confirmed the changes work expected, as shown in the images below.

- 255 characters can be registered.
  <img width="1416" alt="スクリーンショット 2025-02-01 19 22 45" src="https://github.com/user-attachments/assets/c261d236-de4f-4eda-b2c2-b169ee371b5b" />


- 256 characters cannot be registered.
  <img width="1416" alt="スクリーンショット 2025-02-01 19 23 28" src="https://github.com/user-attachments/assets/fc980aba-54fa-4c78-bff4-559526e679d1" />


### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.