### PR TITLE
feat: add contacts note length validation

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,7 +4,7 @@ class Contact < ApplicationRecord
 
   validates :contact_user_id, uniqueness: { scope: :user_id }
   validates :display_name, presence: true, allow_nil: true, length: { maximum: 255 }
-  validates :note, presence: true, allow_nil: true
+  validates :note, presence: true, allow_nil: true, length: { maximum: 1000 }
   validate :not_self_contact, on: :create
   validate :contact_user_must_be_public, on: :create
 


### PR DESCRIPTION
### Summary

This pull request introduces a validation feature for contact notes, ensuring that notes do not exceed a specified length.

### Changes

- Implemented a maximum length validation for contact notes, restricting them to 1000 characters. This change prevents users from saving notes that are too long, enhancing data integrity and user experience.

### Testing

The changes were tested by attempting to save contact notes of edge cases (exactly 1000 characters, 1001 characters). Both tests confirmed that notes exceeding the maximum length are appropriately rejected, while valid notes are saved successfully.

- exactly 1000 characters
  <img width="1416" alt="スクリーンショット 2025-02-01 19 41 26" src="https://github.com/user-attachments/assets/40e52772-0aa7-46f1-bfb4-d9006e6c038e" />

- 1001 characters
  <img width="1416" alt="スクリーンショット 2025-02-01 19 42 55" src="https://github.com/user-attachments/assets/56c9bdfd-3897-45d4-a504-0f15ca1b88db" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.