### PR TITLE
feat!: add exclusion validation for bio on update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: { case_sensitive: false }, length: { maximum: 100 }
   validates :avatar, content_type: { in: %w[image/jpeg image/png] }, size: { less_than_or_equal_to: 2.megabytes },
                      processable_file: true, mime_type_and_extension_consistency: true
-  validates :bio, length: { maximum: 250 }, presence: true, allow_nil: true
+  validates :bio, length: { maximum: 250 }
+  validates :bio, exclusion: [nil], on: :update
 
   def avatar=(value)
     if value.respond_to?(:original_filename) && value.original_filename

--- a/config/locales/active_record.ja.yml
+++ b/config/locales/active_record.ja.yml
@@ -2,6 +2,7 @@
 ja:
   errors:
     messages:
+      exclusion: "に指定された値は使用できません。"
       invalid: "が正しくありません。"
   activerecord:
     errors:


### PR DESCRIPTION
### Summary

This pull request introduces exclusion validation for the bio attribute during updates, ensuring that it cannot be nil. This enhancement aims to improve data integrity by preventing invalid updates user profiles.

### Changes

- Implemented exclusion validation for the bio attribute on update operations.
- Added a new error message for exclusion in the Japanese locale file to support internationalization.

### Testing

The changes were tested by attempting to update the bio attribute with both valid and nil values. The validation correctly prevents updates with nil values and displays the appropriate error message in both English and Japanese.

### Related Issues (Optional)

N/A

### Notes (Optional)

This change is crucial for maintaining the integrity of user data and ensuring that all profiles have valid bios.