### PR TITLE
fix: fix issue with validation error for bio on login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   validates :avatar, content_type: { in: %w[image/jpeg image/png] }, size: { less_than_or_equal_to: 2.megabytes },
                      processable_file: true, mime_type_and_extension_consistency: true
   validates :bio, length: { maximum: 250 }
-  validates :bio, exclusion: [nil], on: :update
+  validates :bio, exclusion: [nil], if: :bio_changed?
 
   def avatar=(value)
     if value.respond_to?(:original_filename) && value.original_filename


### PR DESCRIPTION
### Summary

This pull request addresses an issue with the validation error for the bio field during the login process. It ensures that users do not encounter unnecessary validation errors when their bio has not changed.

### Changes

The bio validation logic has been modified to only exclude nil values if the bio has been altered. This change prevents improper validation errors from occurring at login, enhancing the user experience.

### Testing

The changes were tested by attempting to log in with various bio states (unchanged, changed to nil, and changed to a valid value) to confirm that the validation behaves as expected and does not trigger errors unnecessarily.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.