### PR TITLE
feat!: omit null properties from JSON response

### DIFF
--- a/app/resources/application_resource.rb
+++ b/app/resources/application_resource.rb
@@ -1,3 +1,7 @@
 class ApplicationResource
   include Alba::Resource
+
+  def select(_key, value)
+    !value.nil?
+  end
 end

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -27,3 +27,4 @@ resource_update_method
 search
 contact_users
 current_user_contact
+select


### PR DESCRIPTION
### Summary

This pull request introduces a significant enhancement by omitting null properties from the JSON response. This change aims to improve the clarity and conciseness of the output, making it easier for clients to consume the API response without unnecessary null values.

### Changes

- Added a method to the `ApplicationResource` class that filters out null properties from the JSON response.
- Updated the debride whitelist to include 'select', addressing an erroneous debride error that was previously encountered.

### Testing

Confirmed that null properties are not returned after the changes, as shown in the images below.

- before
  <img width="1406" alt="スクリーンショット 2025-02-08 21 52 27" src="https://github.com/user-attachments/assets/f7329f0c-4c31-4183-a593-c3089d70b134" />

- after
  <img width="1406" alt="スクリーンショット 2025-02-08 21 55 50" src="https://github.com/user-attachments/assets/d54e7864-bc0b-49ba-be50-609194707ac3" />

### Related Issues (Optional)

N/A

### Notes (Optional)

- Important Note: This change is a breaking change (indicated by the `feat!` prefix) and requires updates to any clients consuming the API to handle the new response format.

- Reference URL:  [alba/README.md at main · okuramasafumi/alba](https://tinyurl.com/28w6pmal)