### PR TITLE
feat: remove nil exclusion validations for display_name, note, and bio

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,9 +4,7 @@ class Contact < ApplicationRecord
 
   validates :contact_user_id, uniqueness: { scope: :user_id }
   validates :display_name, length: { maximum: 255 }
-  validates :display_name, exclusion: [nil], if: :display_name_changed?
   validates :note, length: { maximum: 1000 }
-  validates :note, exclusion: [nil], if: :note_changed?
   validate :not_self_contact, on: :create
   validate :contact_user_must_be_public, on: :create
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,6 @@ class User < ApplicationRecord
   validates :avatar, content_type: { in: %w[image/jpeg image/png] }, size: { less_than_or_equal_to: 2.megabytes },
                      processable_file: true, mime_type_and_extension_consistency: true
   validates :bio, length: { maximum: 250 }
-  validates :bio, exclusion: [nil], if: :bio_changed?
 
   def avatar=(value)
     if value.respond_to?(:original_filename) && value.original_filename


### PR DESCRIPTION
### Summary

This pull request introduces changes to remove nil exclusion validations for the `display_name`, `note`, and `bio` attributes. The need for this change arose from the realization that data types like numbers do not have non-null values to indicate emptiness, and they cannot be treated the same way as string types.

### Changes

- Removed nil exclusion validations for the following attributes:
  - `display_name`
  - `note`
  - `bio`

These changes will enable the application to accept nil values for these fields without triggering validation errors.

### Testing

The changes were tested by running the application with various inputs, including nil values for `display_name`, `note`, and `bio`. All tests passed successfully, confirming that the application behaves as expected without the nil exclusion validations.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.