### PR TITLE
feat!: return empty object if user not found when searching

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,7 +11,7 @@ module Api
         @user = User.find_by(email: params[:email], is_private: false)
 
         if @user.nil?
-          render json: { user: nil }, status: :ok
+          render json: {}, status: :ok
         else
           render json: UserResource.new(@user, params: { current_user_contact: }), status: :ok
         end


### PR DESCRIPTION
### Summary

This pull request introduces a significant change to the user search functionality by modifying the response behavior when a user is not found. Instead of returning a null value, the API will now return an empty object, enhancing the consistency of the API response format.

### Changes

- Updated the user search logic to return an empty object (`{}`) when no user is found, rather than returning `null`. This change aims to standardize the API responses.

### Testing

As shown in the images below, I confirmed that an empty object (`{}`) is returned when the specified user does not exist. Additionally, I verified that the expected data is returned when the user does exist.

- No match found

- Match found

### Related Issues (Optional)

N/A

### Notes (Optional)

This change is a breaking change (indicated by the `feat!` prefix) and may require updates to any client applications that rely on the previous behavior of receiving a null value for non-existing users.