### PR TITLE
feat!: change response data on account creation

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -33,6 +33,10 @@ module Api
             @resource.redirect_url = @redirect_url if @resource.present?
           end
 
+          def render_create_success
+            render json: AccountResource.new(@resource), status: :ok
+          end
+
           def render_update_success
             render json: {
               status: "success",

--- a/app/resources/account_resource.rb
+++ b/app/resources/account_resource.rb
@@ -1,0 +1,5 @@
+class AccountResource < ApplicationResource
+  root_key :account
+
+  attributes :id, :name, :email, :is_private, :bio, :avatar_url
+end


### PR DESCRIPTION
### Summary

This pull request introduces a significant change to the account creation process by modifying the response data returned upon successful account creation. 

### Changes

- Over the `render_create_success` method to customize the response data for account creation.
- Created an `AccountResource` to structure the response attributes, ensuring a consistent and clear format for the data returned to the client.

### Testing

The were tested by new accounts and verifying that the response data matches the expected structure defined in the `AccountResource`. All tests passed successfully, confirming that the new response format is functioning as intended.

<img width="1393" alt="スクリーンショット 2025-02-13 22 08 42" src="https://github.com/user-attachments/assets/186ee848-4355-45f1-ae5f-3d6f76922f8a" />


### Related Issues (Optional)

N/A

### Notes (Optional)

This change is marked as a breaking change (feat!) due to the modification of the response structure, which may require updates in the client-side code that consumes this API.