### PR TITLE
feat!: change response for account creation validation errors

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -37,6 +37,10 @@ module Api
             render json: AccountResource.new(@resource), status: :ok
           end
 
+          def render_create_error
+            render json: ErrorResource.new(@resource.errors), status: :unprocessable_entity
+          end
+
           def render_update_success
             render json: AccountResource.new(@resource), status: :ok
           end

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -28,3 +28,4 @@ search
 contact_users
 current_user_contact
 select
+render_create_error


### PR DESCRIPTION
### Summary

This pull request introduces a significant change to the error response format for account creation validation errors. The goal is to ensure consistency across the API, making it easier for clients to handle errors uniformly.

### Changes

- Updated the response format for account creation validation errors to align with the established API standards.
- Added `render_create_error` to the debride whitelist to prevent errors related to improper debride usage.

### Testing

I confirmed that the expected response is returned as shown in the image below.
<img width="1393" alt="スクリーンショット 2025-02-20 15 23 01" src="https://github.com/user-attachments/assets/3ccc1aa0-7f40-4c66-a22d-296b7a155cb4" />

### Related Issues (Optional)

N/A

### Notes (Optional)

This change is a breaking change (`feat!`), so it may require updates in client applications that consume the API.