### PR TITLE
feat!: change validation error response for account updates

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -45,6 +45,10 @@ module Api
             render json: AccountResource.new(@resource), status: :ok
           end
 
+          def render_update_error
+            render json: ErrorResource.new(@resource.errors), status: :unprocessable_entity
+          end
+
           def resource_errors
             @resource.errors.full_messages
           end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -49,10 +49,6 @@ module Api
             render json: ErrorResource.new(@resource.errors), status: :unprocessable_entity
           end
 
-          def resource_errors
-            @resource.errors.full_messages
-          end
-
           def configure_permitted_parameters
             devise_parameter_sanitizer.permit(:sign_up, keys: %i[name])
             devise_parameter_sanitizer.permit(:account_update, keys: %i[name avatar bio is_private])

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -29,3 +29,4 @@ contact_users
 current_user_contact
 select
 render_create_error
+render_update_error


### PR DESCRIPTION
### Summary

This pull request introduces changes to improve the validation error response when updating accounts. It aims to enhance error handling and ensure a consistent response structure.

### Changes

- Overrode the `render_update_error` method in Devise Token Auth to standardize the rendering of validation errors during account updates.
- Added `render_update_error` to the debride whitelist to prevent improper error handling in the debride process.
- Removed the unused `resource_errors` method from the `registrations_controller`, streamlining the codebase.

### Testing

Confirmed that the expected response is returned, as shown in the attached images.
<img width="1393" alt="スクリーンショット 2025-02-21 18 20 09" src="https://github.com/user-attachments/assets/ae40751c-d151-4df8-b853-765a9349a361" />


### Related Issues (Optional)

N/A

### Notes (Optional)

This change may require updates on the client side.