### PR TITLE
feat!: change response for account deletion

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -49,6 +49,10 @@ module Api
             render json: ErrorResource.new(@resource.errors), status: :unprocessable_entity
           end
 
+          def render_destroy_success
+            head :no_content
+          end
+
           def configure_permitted_parameters
             devise_parameter_sanitizer.permit(:sign_up, keys: %i[name])
             devise_parameter_sanitizer.permit(:account_update, keys: %i[name avatar bio is_private])

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -30,3 +30,4 @@ current_user_contact
 select
 render_create_error
 render_update_error
+render_destroy_success


### PR DESCRIPTION
### Summary

This pull request introduces a significant change to the account deletion response, enhancing consistency across our API responses.

### Changes

- Modified the response for account deletion to return a "204 No Content" status, aligning it with the behavior of other successful delete requests.
- Added `render_destroy_success` to the debride whitelist to prevent improper debride error.

### Testing

The changes were tested by performing account deletion requests and verifying that the response status is now "204 No Content".
<img width="1404" alt="スクリーンショット 2025-02-23 23 56 16" src="https://github.com/user-attachments/assets/647e686e-9049-4526-9593-54e0572d8fe8" />

### Related Issues (Optional)

N/A

### Notes (Optional)

This change is a breaking change (indicated by the `feat!` prefix) and may require updates to client implementations that expect a different response format for account deletions.