### PR TITLE
feat!: change registration success response

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -34,7 +34,7 @@ module Api
           end
 
           def render_create_success
-            render json: AccountResource.new(@resource), status: :ok
+            render json: AccountResource.new(@resource), status: :created, location: api_v1_user_url(@resource)
           end
 
           def render_create_error


### PR DESCRIPTION
### Summary

This pull request introduces a significant change to the registration success response of the API. The response status has been updated to 201 Created, and the location of the newly created user is now included in the response. This change enhances the API's compliance with RESTful standards.

### Changes

- Updated the registration success response status to 201 Created.
- Included the location of the newly created user in the response body.

![SCR-20250225-pcuj](https://github.com/user-attachments/assets/1428e6cb-7e18-49ba-8ab7-bb35a140a663)

### Testing

The changes were tested by performing a registration request and verifying that the response status is 201 Created and that the response body contains the correct location of the newly created user.
<img width="1423" alt="SCR-20250225-ozfp" src="https://github.com/user-attachments/assets/32e4d0a7-0c9f-45bd-8e9c-c931fa92d955" />
<img width="1423" alt="SCR-20250225-ozux" src="https://github.com/user-attachments/assets/f9364bb1-1860-4b42-83bd-753ca8e3f788" />

### Related Issues (Optional)

N/A

### Notes (Optional)

This change may require updates to any client applications that consume the registration endpoint to handle the new response format.