### PR TITLE
feat!: change response on successful logout

### DIFF
--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -6,6 +6,10 @@ module Api
           def render_create_success
             render json: AccountResource.new(@resource), status: :ok
           end
+
+          def render_destroy_success
+            head :no_content
+          end
       end
     end
   end


### PR DESCRIPTION
### Summary

This pull request introduces a change to the response format upon successful logout, enhancing consistency across the application.

### Changes

- Overrode the `render_destroy_success` method in DeviseTokenAuth's `sessions_controller.rb` to unify the response format throughout the application, changing the response upon successful logout.
![SCR-20250225-puxx](https://github.com/user-attachments/assets/fd0c8b04-a39f-4200-afae-4dd359a55fa1)

### Testing

Confirmed that expected response is upon successful logout.
<img width="1423" alt="SCR-20250225-puxx2" src="https://github.com/user-attachments/assets/2a4ae410-3b7c-403a-8874-7d75fca08a1e" />

### Related Issues (Optional)

N/A

### Notes (Optional)

This change is a breaking change (indicated by the `feat!` prefix) and may require updates in any client-side code that relies on the previous response format.