### PR TITLE
feat!: change password update success response

### DIFF
--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -48,6 +48,10 @@ module Api
             head :no_content
           end
 
+          def render_update_success
+            render json: AccountResource.new(@resource), status: :ok
+          end
+
           def resource_errors
             super
             @resource.errors.full_messages


### PR DESCRIPTION
### Summary

This pull request introduces a breaking change to the password update response in the API. It adds a new `render_update_success` method to the `Api::V1::Auth::PasswordsController` to return a consistent JSON response when a user updates their password.

### Changes

- Added a new `render_update_success` method to the `Api::V1::Auth::PasswordsController` to return a successful JSON response when a user updates their password.
![before-after-3](https://github.com/user-attachments/assets/8ed6d079-b6f8-49c1-b1ee-98d1c2c68996)

### Testing

The changes were tested by manually updating a user's password and verifying the expected JSON response was returned.
![screen-shot-42](https://github.com/user-attachments/assets/338684ef-e990-45c8-a82c-e0199130e168)

### Related Issues (Optional)

None.

### Notes (Optional)

This is a breaking change, as it modifies the existing password update response. Clients consuming the API may need to be updated to handle the new response format.