### PR TITLE
feat!: change password update error rendering

### DIFF
--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -52,6 +52,10 @@ module Api
             render json: AccountResource.new(@resource), status: :ok
           end
 
+          def render_update_error
+            render json: ErrorResource.new(@resource.errors), status: :unprocessable_entity
+          end
+
           def resource_errors
             super
             @resource.errors.full_messages


### PR DESCRIPTION
### Summary

This pull request introduces a breaking change to the password update functionality, improving the error rendering for password update actions.

### Changes

The main change in this pull request is the addition of a new `render_update_error` method in the `Api::V1::Auth::PasswordsController`. This method is responsible for handling and rendering errors that occur during the password update process, ensuring consistent error handling across the application.
![before-after-6](https://github.com/user-attachments/assets/ea83e3aa-3309-4809-8406-4e04e2a9891a)

### Testing

The changes were tested to ensure that the new `render_update_error` method correctly handles and renders errors when updating a user's password. 
![screen-shot-44](https://github.com/user-attachments/assets/89a0b8eb-b2fb-44ab-ba4d-bbcbca23fea6)

### Related Issues (Optional)

N/A

### Notes (Optional)

This is a breaking change, as it modifies the existing password update response. Clients consuming the API may need to be updated to handle the new response format.