### PR TITLE
refactor: remove unused resource_errors method

### DIFF
--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -55,11 +55,6 @@ module Api
           def render_update_error
             render json: ErrorResource.new(@resource.errors), status: :unprocessable_entity
           end
-
-          def resource_errors
-            super
-            @resource.errors.full_messages
-          end
       end
     end
   end


### PR DESCRIPTION
### Summary

This pull request removes an unused `resource_errors` method from the `passwords_controller.rb` file. The method was no longer being used, so it has been removed to keep the codebase clean and maintainable.

### Changes

The specific change made in this pull request is the removal of the `resource_errors` method from the `passwords_controller.rb` file.

### Testing

The changes were tested to ensure that the removal of the `resource_errors` method does not impact the functionality of the application.

### Related Issues (Optional)

N/A

### Notes (Optional)

N/A