### PR TITLE
feat!: change confirmation success response

### DIFF
--- a/app/controllers/api/v1/auth/confirmations_controller.rb
+++ b/app/controllers/api/v1/auth/confirmations_controller.rb
@@ -22,6 +22,10 @@ module Api
             message = "'#{redirect_url}' へのリダイレクトは許可されていません。"
             render_error(422, message, response)
           end
+
+          def render_create_success
+            head :no_content
+          end
       end
     end
   end


### PR DESCRIPTION
### Summary

This pull request introduces a breaking change to the confirmation success response in the API. The changes aim to improve the response when a confirmation email has been successfully sent.

### Changes

The main change in this pull request is the addition of the `render_create_success` method in the `Api::V1::Auth::ConfirmationsController`. This method will now return a successful response with a `204 No Content` status when a confirmation email has been successfully sent, instead of the previous response.

![before-after-8](https://github.com/user-attachments/assets/44916d0c-dbc6-495c-89a4-6154efece749)

### Testing

The changes have been tested to ensure that the new `render_create_success` method correctly returns the expected `204 No Content` status when a confirmation email has been successfully sent.
![screen-shot-49](https://github.com/user-attachments/assets/7339ce39-ee90-4876-9a84-1c2663e82b2c)

### Related Issues (Optional)

N/A

### Notes (Optional)

This is a breaking change, as it modifies the existing confirmation success response . Clients consuming the API may need to be updated to handle the new response format.