### PR TITLE
chore: fix error when running docker compose build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.4.1"
+ruby "3.4.2"
 
 gem "rails", "~> 8.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,7 +480,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 3.3.6p108
+   ruby 3.4.2p28
 
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
### Summary

This pull request addresses an issue encountered when running `docker compose build`. The changes made aim to resolve the error that arises during the build process.
発生しているエラーは以下のとおりです。

```
$ docker compose build
...
 => ERROR [api stage-0 7/8] RUN --mount=type=cache,uid=1000,target=/home/ruby/.cache/bundle <<-EOF (set -eu...)                      0.3s
------
 > [api stage-0 7/8] RUN --mount=type=cache,uid=1000,target=/home/ruby/.cache/bundle <<-EOF (set -eu...):
0.266 Your Ruby version is 3.4.2, but your Gemfile specified 3.4.1
------
...
```

### Changes

- Updated the Ruby version specified in the Gemfile to a compatible version, which eliminates the errors encountered during the `docker compose build` command.

### Testing

The changes were tested by running `docker compose build` after the Ruby version update. The build process completed successfully without any errors, confirming that the issue has been resolved.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.