### PR TITLE
feat: include provider in account response

### DIFF
--- a/app/resources/account_resource.rb
+++ b/app/resources/account_resource.rb
@@ -1,5 +1,5 @@
 class AccountResource < ApplicationResource
   root_key :account
 
-  attributes :id, :name, :email, :is_private, :bio, :avatar_url
+  attributes :id, :name, :email, :is_private, :bio, :avatar_url, :provider
 end


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Add `provider` to `AccountResource` to enable the use of the `provider` value in the client.

### Changes

<!-- Explain the specific changes or additions made -->
- Add `provider` to `AccountResource`
  This change will add `provider` to the response where `AccountResource` is used, as shown in the following image.
  ![before-after-10](https://github.com/user-attachments/assets/06adc1f6-d14d-4f4a-a58f-9763e34574e3)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
Confirmed that `provider` is added to the `account` response using Bruno.

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.