### PR TITLE
feat: update contacts listing display and pagination

### DIFF
--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -4,8 +4,8 @@ module Api
       before_action :set_contact, only: %i[update destroy]
 
       def index
-        user_contacts = current_api_v1_user.contacts.includes(contact_user: :avatar_attachment).order(:created_at)
-        @pagy, contacts = pagy(user_contacts, items: 20)
+        user_contacts = current_api_v1_user.contacts.includes(contact_user: :avatar_attachment).order(created_at: :DESC)
+        @pagy, contacts = pagy(user_contacts, limit: 18, overflow: :last_page)
 
         render json: ContactResource.new(contacts), status: :ok
       end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -146,7 +146,7 @@ Pagy::DEFAULT[:headers] = { page: "Current-Page",
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow
 require "pagy/extras/overflow"
-Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
+# Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
 
 # Trim extra: Remove the page=1 param from links
 # See https://ddnexus.github.io/pagy/docs/extras/trim


### PR DESCRIPTION
### Summary

Improve contacts listing display and pagination functionality for better user experience.

### Changes

- Change contacts sorting order to newest first (descending creation date order)
- Reduce items per page from 20 to 18
- Add overflow handling to last page for pagination
- Update Pagy configuration for more flexible page handling

### Testing

Verified that the contacts listing API correctly applies the new sorting order and item limit. Confirmed that pagination functionality works as expected, with proper last page display when accessing beyond the final page.

<img width="2248" height="1772" alt="screen-shot-586" src="https://github.com/user-attachments/assets/e82e1a3c-4648-4bb5-8653-3e80f6fcb1a2" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.