### PR TITLE
feat: change contact creation from user ID to email-based lookup

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -6,17 +6,10 @@ class Contact < ApplicationRecord
   validates :display_name, length: { maximum: 255 }
   validates :note, length: { maximum: 1000 }
   validate :not_self_contact, on: :create
-  validate :contact_user_must_be_public, on: :create
 
   def not_self_contact
     return unless user_id == contact_user_id
 
     errors.add(:contact_user, "に自分自身は指定できません。")
-  end
-
-  def contact_user_must_be_public
-    return unless contact_user&.is_private?
-
-    errors.add(:contact_user, "のプライベートモードが有効なため登録できません。")
   end
 end

--- a/config/locales/active_record.ja.yml
+++ b/config/locales/active_record.ja.yml
@@ -27,7 +27,7 @@ ja:
         bio: "自己紹介"
       contact:
         contact_user: "対象ユーザー"
-        contact_user_id: "対象ユーザーID"
+        contact_user_id: "対象ユーザー"
         display_name: "表示名"
         note: "メモ"
     models:


### PR DESCRIPTION
### Summary

Replace contact creation API from user ID-based to email-based lookup for enhanced privacy protection. Users can now add contacts using email addresses, ensuring only users whose email addresses are known can be added as contacts.

### Changes

- **API Enhancement**: Modified contacts controller to accept email parameter instead of contact_user_id
- **User Lookup**: Added email-based user search with automatic filtering of private users
- **Privacy Protection**: Contact creation now requires knowledge of target user's email address
- **Error Handling**: Implemented specific error response for non-existent users
- **Validation Removal**: Removed private user validation from Contact model as it's now handled in controller logic
- **Parameter Update**: Updated strong parameters to remove contact_user_id and handle email separately
- **Localization**: Updated Japanese translations for contact attributes

### Testing

- Verified email-based contact creation works correctly
- Confirmed proper error handling for non-existent users
- Tested private user filtering functionality
- Validated parameter filtering and validation logic

### Related Issues

N/A

### Notes

This change enhances privacy by requiring users to know the email address of the person they want to add as a contact. The email parameter is handled separately from contact attributes, as it's used for user lookup rather than being stored as part of the contact record.