### PR TITLE
feat: add block and unblock functionality to contacts

### DIFF
--- a/.bruno/Collection/Contacts/Block.bru
+++ b/.bruno/Collection/Contacts/Block.bru
@@ -1,12 +1,12 @@
 meta {
-  name: Destroy
+  name: Block
   type: http
-  seq: 6
+  seq: 4
 }
 
-delete {
-  url: {{BASE_URL}}/{{API_VERSION}}/contacts/2
-  body: json
+patch {
+  url: {{BASE_URL}}/{{API_VERSION}}/contacts/1/block
+  body: none
   auth: bearer
 }
 

--- a/.bruno/Collection/Contacts/Create.bru
+++ b/.bruno/Collection/Contacts/Create.bru
@@ -1,7 +1,7 @@
 meta {
   name: Create
   type: http
-  seq: 3
+  seq: 2
 }
 
 post {

--- a/.bruno/Collection/Contacts/Unblock.bru
+++ b/.bruno/Collection/Contacts/Unblock.bru
@@ -1,12 +1,12 @@
 meta {
-  name: Destroy
+  name: Unblock
   type: http
-  seq: 6
+  seq: 5
 }
 
-delete {
-  url: {{BASE_URL}}/{{API_VERSION}}/contacts/2
-  body: json
+patch {
+  url: {{BASE_URL}}/{{API_VERSION}}/contacts/1/unblock
+  body: none
   auth: bearer
 }
 

--- a/.bruno/Collection/Contacts/Update.bru
+++ b/.bruno/Collection/Contacts/Update.bru
@@ -1,7 +1,7 @@
 meta {
   name: Update
   type: http
-  seq: 4
+  seq: 3
 }
 
 patch {

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ContactsController < ApplicationController
-      before_action :set_contact, only: %i[update destroy]
+      before_action :set_contact, only: %i[update destroy block unblock]
 
       def index
         user_contacts = current_api_v1_user.contacts.includes(contact_user: :avatar_attachment).order(created_at: :DESC)
@@ -36,6 +36,22 @@ module Api
       def destroy
         @contact.destroy
         head :no_content
+      end
+
+      def block
+        if @contact.update(blocked_at: Time.current)
+          render json: ContactResource.new(@contact), status: :ok
+        else
+          render_validation_error
+        end
+      end
+
+      def unblock
+        if @contact.update(blocked_at: nil)
+          render json: ContactResource.new(@contact), status: :ok
+        else
+          render_validation_error
+        end
       end
 
       private

--- a/app/resources/contact_resource.rb
+++ b/app/resources/contact_resource.rb
@@ -3,5 +3,9 @@ class ContactResource < ApplicationResource
 
   attributes :id, :display_name, :note
 
+  attribute :is_blocked do |contact|
+    contact.blocked_at.present?
+  end
+
   one :contact_user, resource: UserResource
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,12 @@ Rails.application.routes.draw do
         resources :users, only: :show do
           get "search", on: :collection
 
-          resources :contacts, except: :show
+          resources :contacts, except: :show do
+            member do
+              patch :block
+              patch :unblock
+            end
+          end
         end
       end
     end

--- a/db/migrate/20250819015629_add_is_blocked_to_contacts.rb
+++ b/db/migrate/20250819015629_add_is_blocked_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddIsBlockedToContacts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contacts, :is_blocked, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250819020300_remove_is_blocked_indexes_from_contacts.rb
+++ b/db/migrate/20250819020300_remove_is_blocked_indexes_from_contacts.rb
@@ -1,0 +1,6 @@
+class RemoveIsBlockedIndexesFromContacts < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :contacts, :is_blocked
+    remove_index :contacts, [:user_id, :is_blocked]
+  end
+end

--- a/db/migrate/20250819110939_replace_is_blocked_with_blocked_at_in_contacts.rb
+++ b/db/migrate/20250819110939_replace_is_blocked_with_blocked_at_in_contacts.rb
@@ -1,0 +1,7 @@
+class ReplaceIsBlockedWithBlockedAtInContacts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contacts, :blocked_at, :timestamp, null: true
+    remove_column :contacts, :is_blocked, :boolean
+    add_index :contacts, [:user_id, :blocked_at]
+  end
+end

--- a/db/migrate/20250820003627_remove_user_id_blocked_at_index_from_contacts.rb
+++ b/db/migrate/20250820003627_remove_user_id_blocked_at_index_from_contacts.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdBlockedAtIndexFromContacts < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :contacts, [:user_id, :blocked_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_20_040935) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_003627) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_ja_0900_as_cs", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_20_040935) do
     t.datetime "updated_at", null: false
     t.string "display_name"
     t.text "note"
+    t.timestamp "blocked_at"
     t.index ["contact_user_id"], name: "index_contacts_on_contact_user_id"
     t.index ["user_id", "contact_user_id"], name: "index_contacts_on_user_id_and_contact_user_id", unique: true
     t.index ["user_id"], name: "index_contacts_on_user_id"

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -32,3 +32,5 @@ render_create_error
 render_update_error
 render_destroy_success
 avatar_url
+block
+unblock


### PR DESCRIPTION
### Summary

This pull request adds complete block and unblock functionality for contacts using a timestamp-based implementation. The feature allows users to block and unblock contacts while providing the foundation for future sorting capabilities by block date.

### Changes

- Add `block` and `unblock` actions to `ContactsController` with PATCH method endpoints
- Add `blocked_at` timestamp column to contacts table to track when a contact was blocked
- Update `ContactResource` to return `is_blocked` as a computed attribute based on `blocked_at` presence
- Add routing configuration for block/unblock endpoints under contacts resources
- Add Bruno API test collections for testing block and unblock functionality
- Include database migrations for schema changes with proper rollback support

### Testing

Tested the functionality by executing Block.bru and Unblock.bru.

<img width="2248" height="1772" alt="screen-shot-587" src="https://github.com/user-attachments/assets/99d6afdf-7e6f-439c-8db4-230fb2a997aa" />

<img width="2248" height="1772" alt="screen-shot-588" src="https://github.com/user-attachments/assets/bf06a322-659d-4892-b31a-549e801a62f7" />

### Related Issues

N/A

### Notes

The implementation uses `blocked_at` timestamp instead of a simple boolean to enable future sorting by block date while maintaining API compatibility through the computed `is_blocked` attribute.
