### PR TITLE
feat: add blocked contacts listing API endpoint

### DIFF
--- a/.bruno/Collection/Contacts/Blocked.bru
+++ b/.bruno/Collection/Contacts/Blocked.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Blocked
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{BASE_URL}}/{{API_VERSION}}/users/1/contacts/blocked?page=1
+  body: none
+  auth: bearer
+}
+
+params:query {
+  page: 1
+}
+
+headers {
+  Origin: {{FRONTEND_ORIGIN}}
+}
+
+auth:bearer {
+  token: {{BEARER_TOKEN}}
+}

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -4,8 +4,17 @@ module Api
       before_action :set_contact, only: %i[update destroy block unblock]
 
       def index
-        user_contacts = current_api_v1_user.contacts.includes(contact_user: :avatar_attachment).order(created_at: :DESC)
+        user_contacts = current_api_v1_user.contacts.includes(contact_user: :avatar_attachment).order(created_at: :desc)
         @pagy, contacts = pagy(user_contacts, limit: 18, overflow: :last_page)
+
+        render json: ContactResource.new(contacts), status: :ok
+      end
+
+      def blocked
+        blocked_contacts = current_api_v1_user.contacts.blocked
+                                              .includes(contact_user: :avatar_attachment)
+                                              .order(blocked_at: :desc)
+        @pagy, contacts = pagy(blocked_contacts, limit: 18, overflow: :last_page)
 
         render json: ContactResource.new(contacts), status: :ok
       end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -7,6 +7,8 @@ class Contact < ApplicationRecord
   validates :note, length: { maximum: 1000 }
   validate :not_self_contact, on: :create
 
+  scope :blocked, -> { where.not(blocked_at: nil) }
+
   def not_self_contact
     return unless user_id == contact_user_id
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
           get "search", on: :collection
 
           resources :contacts, except: :show do
+            get :blocked, on: :collection
             member do
               patch :block
               patch :unblock

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,12 +40,16 @@ Contact.destroy_all
 # Create contacts for test user.
 test_user = User.find_by(email: "test@example.com")
 other_users = User.where.not(id: test_user.id)
-other_users.each do |contact_user|
+other_users.each_with_index do |contact_user, index|
+  is_blocked = (index % 5).zero?
+  blocked_at = is_blocked ? Faker::Time.between(from: 30.days.ago, to: Time.current) : nil
+
   Contact.create!(
     user_id: test_user.id,
     contact_user_id: contact_user.id,
     display_name: Faker::Name.name,
-    note: Faker::Lorem.paragraph(sentence_count: 3)
+    note: Faker::Lorem.paragraph(sentence_count: 3),
+    blocked_at: blocked_at
   )
 rescue ActiveRecord::RecordInvalid
   next


### PR DESCRIPTION
### Summary

Add blocked contacts listing functionality to the contacts API. This feature provides a dedicated endpoint to retrieve and display contacts that have been blocked by the authenticated user.

### Changes

- Add GET /api/v1/contacts/blocked endpoint for retrieving blocked contacts
- Implement blocked scope in Contact model for efficient querying
- Add proper pagination support with Pagy (18 items per page)
- Include Bruno API test configuration for the new endpoint
- Update seed data to include blocked contact test scenarios

### Testing

- Executed Bruno API test case "Blocked" and confirmed proper functionality

<img width="2248" height="1772" alt="screen-shot-589" src="https://github.com/user-attachments/assets/c3a2d92a-2ef5-41dd-94fb-ec3727faf3bc" />


### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.