### PR TITLE
feat: add user suggestions API endpoint

### DIFF
--- a/.bruno/Collection/Auth/folder.bru
+++ b/.bruno/Collection/Auth/folder.bru
@@ -1,3 +1,4 @@
 meta {
   name: Auth
+  seq: 2
 }

--- a/.bruno/Collection/Contacts/folder.bru
+++ b/.bruno/Collection/Contacts/folder.bru
@@ -1,3 +1,4 @@
 meta {
   name: Contacts
+  seq: 3
 }

--- a/.bruno/Collection/Users/Show.bru
+++ b/.bruno/Collection/Users/Show.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASE_URL}}/{{API_VERSION}}/users/1
+  url: {{BASE_URL}}/{{API_VERSION}}/users/2
   body: none
   auth: bearer
 }

--- a/.bruno/Collection/Users/Suggestions.bru
+++ b/.bruno/Collection/Users/Suggestions.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Suggestions
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{BASE_URL}}/{{API_VERSION}}/users/suggestions?page=1
+  body: none
+  auth: bearer
+}
+
+params:query {
+  page: 1
+}
+
+auth:bearer {
+  token: {{BEARER_TOKEN}}
+}
+
+settings {
+  encodeUrl: true
+}

--- a/.bruno/Collection/Users/folder.bru
+++ b/.bruno/Collection/Users/folder.bru
@@ -1,3 +1,4 @@
 meta {
   name: Users
+  seq: 4
 }

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,10 @@ module Api
       def show
         @user = User.find(params[:id])
 
-        render json: UserResource.new(@user, params: { current_user_contact: }), status: :ok
+        render json: UserResource.new(@user, params: {
+          current_user_contact: current_user_contact,
+          suggestion_user_ids: current_api_v1_user.suggestion_user_ids
+        }), status: :ok
       end
 
       def search
@@ -13,8 +16,18 @@ module Api
         if @user.nil?
           render json: {}, status: :ok
         else
-          render json: UserResource.new(@user, params: { current_user_contact: }), status: :ok
+          render json: UserResource.new(@user, params: {
+            current_user_contact: current_user_contact,
+            suggestion_user_ids: current_api_v1_user.suggestion_user_ids
+          }), status: :ok
         end
+      end
+
+      def suggestions
+        suggestion_users = current_api_v1_user.suggestion_users
+        @pagy, users = pagy(suggestion_users, limit: 18, overflow: :last_page)
+
+        render json: UserResource.new(users), status: :ok
       end
 
       private

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -6,4 +6,8 @@ class UserResource < ApplicationResource
   attribute :current_user_contact, if: proc { !params[:current_user_contact].nil? } do
     ContactResource.new(params[:current_user_contact], within: :user).to_h
   end
+
+  attribute :is_suggested, if: proc { params[:suggestion_user_ids].present? } do |user|
+    params[:suggestion_user_ids].include?(user.id)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       shallow do
         resources :users, only: :show do
           get "search", on: :collection
+          get "suggestions", on: :collection
 
           resources :contacts, except: :show do
             get :blocked, on: :collection

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,20 +37,90 @@ end
 
 # Delete all contacts.
 Contact.destroy_all
-# Create contacts for test user.
+
+# Create contacts for test user with specific relationship patterns
 test_user = User.find_by(email: "test@example.com")
-other_users = User.where.not(id: test_user.id)
-other_users.each_with_index do |contact_user, index|
-  is_blocked = (index % 5).zero?
+User.where.not(id: test_user.id)
+public_users = User.where(is_private: false).where.not(id: test_user.id)
+
+# Test user -> other users (unidirectional relationship)
+reverse_only_users = public_users.limit(25)
+Rails.logger.debug "Creating reverse-only relationships (test_user -> others)..."
+reverse_only_users.each_with_index do |contact_user, index|
+  is_blocked = (index % 8).zero? # Block every 8th user
   blocked_at = is_blocked ? Faker::Time.between(from: 30.days.ago, to: Time.current) : nil
 
   Contact.create!(
     user_id: test_user.id,
     contact_user_id: contact_user.id,
-    display_name: Faker::Name.name,
-    note: Faker::Lorem.paragraph(sentence_count: 3),
+    display_name: "#{contact_user.name} (reverse only)",
+    note: "Unidirectional relationship test (test -> other) - #{Faker::Lorem.sentence}",
     blocked_at: blocked_at
   )
-rescue ActiveRecord::RecordInvalid
+rescue ActiveRecord::RecordInvalid => e
+  Rails.logger.debug { "Reverse-only contact creation failed: #{e.message}" }
   next
+end
+
+# Unidirectional relationship (other users -> test user)
+Rails.logger.debug "Creating unidirectional relationships (others -> test_user)..."
+unidirectional_users = public_users.offset(35).limit(8)
+unidirectional_users.each_with_index do |user, index|
+  is_blocked = (index % 7).zero? # Block every 7th user
+  blocked_at = is_blocked ? Faker::Time.between(from: 7.days.ago, to: Time.current) : nil
+
+  Contact.create!(
+    user_id: user.id,
+    contact_user_id: test_user.id,
+    display_name: "Test user registered by #{user.name}",
+    note: "Unidirectional relationship test (other -> test) - #{Faker::Lorem.sentence}",
+    blocked_at: blocked_at
+  )
+rescue ActiveRecord::RecordInvalid => e
+  Rails.logger.debug { "Unidirectional contact creation failed: #{e.message}" }
+  next
+end
+
+# Mutual relationship (test user <-> other users)
+Rails.logger.debug "Creating mutual relationships (test_user <-> others)..."
+mutual_users = public_users.offset(25).limit(10)
+mutual_users.each_with_index do |user, index|
+  is_blocked_forward = (index % 8).zero? # Block every 8th user
+  blocked_at_forward = is_blocked_forward ? Faker::Time.between(from: 10.days.ago, to: Time.current) : nil
+
+  Contact.create!(
+    user_id: test_user.id,
+    contact_user_id: user.id,
+    display_name: "#{user.name} (mutual)",
+    note: "Mutual relationship (test -> other) - #{Faker::Lorem.sentence}",
+    blocked_at: blocked_at_forward
+  )
+
+  # Other users -> test user (create reverse direction)
+  is_blocked_reverse = (index % 6).zero? # Block every 6th user
+  blocked_at_reverse = is_blocked_reverse ? Faker::Time.between(from: 5.days.ago, to: Time.current) : nil
+
+  Contact.create!(
+    user_id: user.id,
+    contact_user_id: test_user.id,
+    display_name: "Test user registered by #{user.name} (mutual)",
+    note: "Mutual relationship (other -> test) - #{Faker::Lorem.sentence}",
+    blocked_at: blocked_at_reverse
+  )
+rescue ActiveRecord::RecordInvalid => e
+  Rails.logger.debug { "Mutual contact creation failed: #{e.message}" }
+  next
+end
+
+Rails.logger.debug "\n=== Relationship pattern creation completed ==="
+Rails.logger.debug { "- Reverse only (test_user -> others): #{reverse_only_users.count} users" }
+Rails.logger.debug { "- Unidirectional (others -> test_user): #{unidirectional_users.count} users" }
+Rails.logger.debug { "- Mutual (test_user <-> others): #{mutual_users.count} users" }
+Rails.logger.debug do
+  "- No relationship: #{100 - reverse_only_users.count - unidirectional_users.count - mutual_users.count} users"
+end
+
+Rails.logger.debug "\n=== Test data preparation for suggestions feature completed ==="
+Rails.logger.debug do
+  "Number of users that should appear in suggestions: #{unidirectional_users.count} (unidirectional relationships)"
 end

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -34,3 +34,5 @@ render_destroy_success
 avatar_url
 block
 unblock
+suggestions
+reverse_contacts


### PR DESCRIPTION
### Summary

Add user suggestions feature to display "you may know" candidates based on reverse contact relationships. This feature helps users discover potential connections from people who have added them as contacts but haven't been added back.

### Changes

- Add `GET /api/v1/users/suggestions` endpoint with pagination support (18 users per page)
- Add `suggestion_users` and `suggestion_user_ids` methods to User model for efficient candidate retrieval
- Add `is_suggested` attribute to UserResource for suggestion marking
- Update existing user endpoints (show/search) to include suggestion status
- Add reverse contact relationships (`reverse_contacts` and `reverse_contact_users`) to User model
- Update seeds.rb to create comprehensive test data with various relationship patterns
- Add Bruno API test for the new suggestions endpoint
- Update debride whitelist for new methods

### Testing

- API endpoint tested with Bruno CLI collection
- Pagination functionality validated (18 users per page with overflow handling)
- Test data includes various relationship patterns (unidirectional, mutual, blocked)
- Verified suggestion logic excludes already connected users and blocked relationships

### Related Issues

N/A

### Notes

No additional information or considerations at this time.