### PR TITLE
fix: correct contact blocking to target reverse contacts

### DIFF
--- a/.bruno/Collection/Contacts/Destroy.bru
+++ b/.bruno/Collection/Contacts/Destroy.bru
@@ -1,7 +1,7 @@
 meta {
   name: Destroy
   type: http
-  seq: 6
+  seq: 7
 }
 
 delete {

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -1,7 +1,8 @@
 module Api
   module V1
     class ContactsController < ApplicationController
-      before_action :set_contact, only: %i[update destroy block unblock]
+      before_action :set_contact, only: %i[update destroy]
+      before_action :set_reverse_contact, only: %i[block unblock]
 
       def index
         user_contacts = current_api_v1_user.contacts_with_users.order(created_at: :desc)
@@ -70,6 +71,10 @@ module Api
 
         def set_contact
           @contact = current_api_v1_user.contacts.find(params[:id])
+        end
+
+        def set_reverse_contact
+          @contact = current_api_v1_user.reverse_contacts.find(params[:id])
         end
 
         def find_target_user


### PR DESCRIPTION
### Summary

Fix contact blocking functionality to correctly target reverse contacts instead of user's own contacts. This allows users to block those who have added them as contacts, which is the intended behavior for blocking functionality.

### Changes

- Separate `before_action` filters for different contact operations
- Add `set_reverse_contact` method to target `reverse_contacts` for block/unblock operations
- Maintain `set_contact` method for update/destroy operations targeting user's own contacts
- Update Bruno API test configuration sequence

### Testing

- Code quality checks passed (RuboCop, Debride)
- All pre-commit hooks executed successfully
- Bruno API tests executed and verified functionality

<img width="2248" height="1772" alt="screen-shot-594" src="https://github.com/user-attachments/assets/1d1bd136-8ffc-4aea-a353-4b70906bb344" />

<img width="2248" height="1772" alt="screen-shot-595" src="https://github.com/user-attachments/assets/d8a88363-2dd9-45c0-b448-db1636e51a1c" />

### Related Issues (Optional)

Related Issues: N/A

### Notes (Optional)

Notes: This change corrects the blocking logic where users can now block contacts who have added them, rather than trying to block their own contacts which doesn't make logical sense. Users should delete their own contacts instead of blocking them.