### PR TITLE
fix: correct validation error type for self-contact prevention

### DIFF
--- a/.bruno/Collection/Blocks/folder.bru
+++ b/.bruno/Collection/Blocks/folder.bru
@@ -1,3 +1,4 @@
 meta {
   name: Blocks
+  seq: 3
 }

--- a/.bruno/Collection/Contacts/folder.bru
+++ b/.bruno/Collection/Contacts/folder.bru
@@ -1,4 +1,4 @@
 meta {
   name: Contacts
-  seq: 3
+  seq: 4
 }

--- a/.bruno/Collection/Users/folder.bru
+++ b/.bruno/Collection/Users/folder.bru
@@ -1,4 +1,4 @@
 meta {
   name: Users
-  seq: 4
+  seq: 5
 }

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,11 +5,12 @@ class Contact < ApplicationRecord
   validates :contact_user_id, uniqueness: { scope: :user_id }
   validates :display_name, length: { maximum: 255 }
   validates :note, length: { maximum: 1000 }
-  validate :not_self_contact, on: :create
+  validate :cannot_add_self_contact, on: :create
 
-  def not_self_contact
-    return unless user_id == contact_user_id
+  private
+    def cannot_add_self_contact
+      return unless user_id == contact_user_id
 
-    errors.add(:contact_user, "に自分自身は指定できません。")
-  end
+      errors.add(:contact_user, :cannot_add_self_contact, message: "に自分自身は指定できません。")
+    end
 end


### PR DESCRIPTION
### Summary

Fix validation error type handling for self-contact prevention in Contact model to ensure proper API error responses.

<img width="2248" height="1772" alt="screen-shot-605" src="https://github.com/user-attachments/assets/611bc9b8-6cd8-4d4b-ba5e-c6d509bbca30" />

### Changes

- Rename `not_self_contact` validation method to `cannot_add_self_contact` for better clarity
- Add `:cannot_add_self_contact` symbol to `errors.add` to ensure proper error type in API responses
- Move validation method to `private` section for better encapsulation
- Update Bruno collection sequence numbers to accommodate blocks integration

### Testing

Verified functionality using Bruno API testing.

<img width="2248" height="1772" alt="screen-shot-606" src="https://github.com/user-attachments/assets/be2e08e9-e658-4f0a-889d-21bb259d1420" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.