### PR TITLE
refactor: remove block-related routes from contacts resource

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,13 +16,7 @@ Rails.application.routes.draw do
           get "search", on: :collection
           get "suggestions", on: :collection
 
-          resources :contacts, except: :show do
-            get :blocked, on: :collection
-            member do
-              patch :block
-              patch :unblock
-            end
-          end
+          resources :contacts, except: :show
 
           resources :blocks, only: %i[index create destroy]
         end


### PR DESCRIPTION
### Summary

Remove block-related routes from the contacts resource to separate concerns and improve API structure. Block operations are now handled exclusively through the dedicated blocks resource.

### Changes

- Remove `get :blocked` collection route from contacts resource
- Remove `patch :block` and `patch :unblock` member routes from contacts resource

### Testing

- Verified route generation with `rails routes` command
- Confirmed that contacts routes no longer include block-related endpoints

- Before
```text
$ rails routes -c contacts -u
Found 3 unused routes:

                      Prefix Verb  URI Pattern                                       Controller#Action
blocked_api_v1_user_contacts GET   /api/v1/users/:user_id/contacts/blocked(.:format) api/v1/contacts#blocked
        block_api_v1_contact PATCH /api/v1/contacts/:id/block(.:format)              api/v1/contacts#block
      unblock_api_v1_contact PATCH /api/v1/contacts/:id/unblock(.:format)            api/v1/contacts#unblock
```

- After
```text
$ rails routes -c contacts -u
No unused routes found for this controller.
```

### Related Issues

N/A

### Notes

No additional information or considerations at this time.