### PR TITLE
feat!: delete user search functionality

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,20 +11,6 @@ module Api
         }), status: :ok
       end
 
-      def search
-        @user = User.find_by(email: params[:email], is_private: false)
-
-        if @user.nil?
-          render json: {}, status: :ok
-        else
-          render json: UserResource.new(@user, params: {
-            current_user_contact: current_user_contact,
-            current_user_block: current_user_block,
-            suggestion_user_ids: current_api_v1_user.suggestion_user_ids
-          }), status: :ok
-        end
-      end
-
       def suggestions
         suggestion_users = current_api_v1_user.suggestion_users
         @pagy, users = pagy(suggestion_users, limit: 18, overflow: :last_page)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
 
       shallow do
         resources :users, only: :show do
-          get "search", on: :collection
           get "suggestions", on: :collection
 
           resources :contacts, except: :show


### PR DESCRIPTION
### Summary

**BREAKING CHANGE**: Remove user search functionality as it is no longer needed. This removes the `/api/v1/users/search` endpoint. Contact creation now uses email addresses directly instead of requiring users to search for users first.

### Changes

- Remove `search` action from UsersController
- Remove `get "search"` collection route from users resource
- **BREAKING**: `/api/v1/users/search` endpoint no longer available

### Testing

- Verified that search routes no longer exist with `rails routes | grep search`
- Confirmed that suggestions functionality remains intact

### Related Issues

N/A

### Notes

This is a breaking change as it removes a public API endpoint that may be used by clients.