### PR TITLE
fix: prioritize validation errors over access control in contact creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,10 +57,6 @@ class User < ApplicationRecord
     suggestion_users.pluck(:id)
   end
 
-  def find_suggestion_user(contact_user_id)
-    suggestion_users.find_by(id: contact_user_id)
-  end
-
   def blocked_by?(user)
     reverse_blocks.exists?(blocker: user)
   end


### PR DESCRIPTION
### Summary

Execute contact validation before access permission checks to ensure validation errors (like uniqueness violations) are returned with proper error format instead of being masked by access control errors.

- Before
```text
{
  "error": {
    "source": "contact_user_id",
    "type": "not_allowed",
    "message": "メールアドレスで登録してください。"
  }
}
```
- After
```text
{
  "errors": [
    {
      "source": "contact_user_id",
      "type": "taken",
      "message": "対象ユーザーはすでに登録されています。"
    }
  ]
}
```

### Changes

- Move contact.invalid? check before contact_user_access_allowed? to prioritize validation errors
- Consolidate contact user access verification logic into contact_user_access_allowed? method  
- Remove redundant find_target_user helper methods from ContactsController
- Remove unused find_suggestion_user method from User model

### Testing

Tested using Bruno API testing tool to verify that duplicate contact creation now returns appropriate "taken" validation error instead of misleading access control error.

<img width="2248" height="1772" alt="screen-shot-630" src="https://github.com/user-attachments/assets/c309ed0d-e7ad-4fec-afd0-aa992c18bd14" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.