### PR TITLE
feat: enable client-configurable pagination limits

### DIFF
--- a/.bruno/Collection/Blocks/Index.bru
+++ b/.bruno/Collection/Blocks/Index.bru
@@ -5,13 +5,14 @@ meta {
 }
 
 get {
-  url: {{BASE_URL}}/{{API_VERSION}}/users/1/blocks?page=1
+  url: {{BASE_URL}}/{{API_VERSION}}/users/1/blocks?page=1&limit=6
   body: none
   auth: bearer
 }
 
 params:query {
   page: 1
+  limit: 6
 }
 
 auth:bearer {

--- a/.bruno/Collection/Contacts/Index.bru
+++ b/.bruno/Collection/Contacts/Index.bru
@@ -5,13 +5,14 @@ meta {
 }
 
 get {
-  url: {{BASE_URL}}/{{API_VERSION}}/users/1/contacts?page=1
+  url: {{BASE_URL}}/{{API_VERSION}}/users/1/contacts?page=1&limit=6
   body: none
   auth: bearer
 }
 
 params:query {
   page: 1
+  limit: 6
 }
 
 auth:bearer {

--- a/.bruno/Collection/Users/Suggestions.bru
+++ b/.bruno/Collection/Users/Suggestions.bru
@@ -5,13 +5,14 @@ meta {
 }
 
 get {
-  url: {{BASE_URL}}/{{API_VERSION}}/users/suggestions?page=1
+  url: {{BASE_URL}}/{{API_VERSION}}/users/suggestions?page=1&limit=6
   body: none
   auth: bearer
 }
 
 params:query {
   page: 1
+  limit: 6
 }
 
 auth:bearer {

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -7,7 +7,7 @@ module Api
       def index
         user_blocks = @user.blocks.includes(blocked: :avatar_attachment).order(created_at: :desc)
 
-        @pagy, blocks = pagy(user_blocks, limit: 18, overflow: :last_page)
+        @pagy, blocks = pagy(user_blocks, overflow: :last_page)
         render json: BlockResource.new(blocks), status: :ok
       end
 

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       def index
         user_contacts = @user.contacts.includes(contact_user: :avatar_attachment).order(created_at: :desc)
-        @pagy, contacts = pagy(user_contacts, limit: 18, overflow: :last_page)
+        @pagy, contacts = pagy(user_contacts, overflow: :last_page)
 
         render json: ContactResource.new(contacts), status: :ok
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,7 +13,7 @@ module Api
 
       def suggestions
         suggestion_users = current_api_v1_user.suggestion_users
-        @pagy, users = pagy(suggestion_users, limit: 18, overflow: :last_page)
+        @pagy, users = pagy(suggestion_users, overflow: :last_page)
 
         render json: UserResource.new(users), status: :ok
       end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -9,7 +9,7 @@
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 # Here are the few that make more sense as DEFAULTs:
-# Pagy::DEFAULT[:limit]       = 20                    # default
+Pagy::DEFAULT[:limit] = 18
 # Pagy::DEFAULT[:size]        = 7                     # default
 # Pagy::DEFAULT[:ends]        = true                  # default
 # Pagy::DEFAULT[:page_param]  = :page                 # default
@@ -137,11 +137,11 @@ Pagy::DEFAULT[:headers] = { page: "Current-Page",
 
 # Limit extra: Allow the client to request a custom limit per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/docs/extras/limit
-# require 'pagy/extras/limit'
+require "pagy/extras/limit"
 # set to false only if you want to make :limit_extra an opt-in variable
-# Pagy::DEFAULT[:limit_extra] = false    # default true
-# Pagy::DEFAULT[:limit_param] = :limit   # default
-# Pagy::DEFAULT[:limit_max]   = 100      # default
+Pagy::DEFAULT[:limit_extra] = true     # default true
+Pagy::DEFAULT[:limit_param] = :limit   # default
+Pagy::DEFAULT[:limit_max]   = 100      # default
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/docs/extras/overflow


### PR DESCRIPTION
### Summary

Enable Pagy limit extra to allow clients to specify custom page limits via query parameters. This enhancement provides flexibility for frontend applications to control pagination based on their specific needs while maintaining security through maximum limit constraints.

### Changes

- Enable pagy/extras/limit with security constraints (max limit: 100)
- Set application default limit to 18 items per page
- Remove hardcoded limit: 18 from contacts, users, and blocks controllers
- Allow dynamic limit resolution through query parameters
- Update Bruno API test files with limit=6 parameter examples

### Testing

- Updated Bruno API collection files with limit parameter examples
- All existing functionality preserved with default limit of 18
- Maximum security limit of 100 prevents abuse
- Lefthook pre-commit hooks passed (RuboCop, Debride, branch protection)

<img width="2248" height="1772" alt="screen-shot-640" src="https://github.com/user-attachments/assets/595ce161-dae1-4ee0-97ae-4e76208e6f45" />
<img width="2248" height="1772" alt="screen-shot-641" src="https://github.com/user-attachments/assets/76c73742-0fa7-4b08-b9db-8b847af8b67b" />
<img width="2248" height="1772" alt="screen-shot-642" src="https://github.com/user-attachments/assets/f270070d-b983-4b30-8b56-26527bbf2b78" />
<img width="2248" height="1772" alt="screen-shot-643" src="https://github.com/user-attachments/assets/67a1b17b-77ce-44ed-803c-de8694132e0c" />
<img width="2248" height="1772" alt="screen-shot-644" src="https://github.com/user-attachments/assets/7ad072cb-8717-4a82-a32a-3ace6489c7ce" />
<img width="2248" height="1772" alt="screen-shot-645" src="https://github.com/user-attachments/assets/d315c794-a97d-4f10-89f0-3818b4fbd3cb" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.