### PR TITLE
feat: add blocked user validation to contact creation

### DIFF
--- a/.bruno/Collection/Contacts/Create.bru
+++ b/.bruno/Collection/Contacts/Create.bru
@@ -20,8 +20,8 @@ auth:bearer {
 
 body:json {
   {
-      "contact_user_id": 2,
-      "email": "zachariah.ullrich@spinka.example",
+      "contact_user_id": 195,
+      "email": "jonathon@prohaska-bergnaum.example",
       "display_name": "宮沢 賢治",
       "note": "そして一しんに勉強して実験でちゃんとほんとうの考えというものは、みんな天の川の砂の上にもいろいろなあかりがいっぱいなのでした。けれどもなぜかまた額に深く皺を刻んでいくのでした。そしてまもなくジョバンニは走りだして黒い丘の方へ出しました。あんなにうしろへ行って半分ばかりのんでしまいました。ぼくはそのひとのために、カムパネルラのためにいったいどうしたらいいのだろうジョバンニは、そのきれいな野原を指して叫びました。"
   }

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,12 +5,18 @@ class Contact < ApplicationRecord
   validates :contact_user_id, uniqueness: { scope: :user_id }
   validates :display_name, length: { maximum: 255 }
   validates :note, length: { maximum: 1000 }
-  validate :cannot_add_self_contact, on: :create
+  validate :cannot_add_self_contact, :cannot_add_blocked_user, on: :create
 
   private
     def cannot_add_self_contact
       return unless user_id == contact_user_id
 
       errors.add(:contact_user, :cannot_add_self_contact, message: "に自分自身は指定できません。")
+    end
+
+    def cannot_add_blocked_user
+      return unless user.blocked_users.exists?(contact_user.id)
+
+      errors.add(:contact_user, :cannot_add_blocked_user, message: "はブロックしているため登録できません。")
     end
 end

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -37,3 +37,4 @@ unblock
 suggestions
 reverse_contacts
 blocker
+cannot_add_blocked_user


### PR DESCRIPTION
### Summary

Add validation to prevent users from adding blocked users as contacts. This feature implements the `cannot_add_blocked_user` validation in the Contact model to maintain data integrity and user privacy.

### Changes

- Add `cannot_add_blocked_user` validation to Contact model that checks if user has blocked the contact_user
- Add Japanese error message for blocked contact attempts
- Update seeds.rb with 300-user separation strategy to prevent data conflicts between contact and block relationships
- Add method to debride-whitelist.txt to prevent false positive warnings
- Update Bruno API test collection with new user IDs


### Testing

- Validation prevents contact creation when user has blocked the contact_user
- Seeds.rb creates separated user groups to avoid data conflicts
- RuboCop and Debride quality checks pass
- Confirmed validation functions correctly using Bruno API testing tool

<img width="2248" height="1772" alt="screen-shot-648" src="https://github.com/user-attachments/assets/d8136eed-8b7e-4da1-8a43-355876bad278" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.