### PR TITLE
feat: add validation to prevent blocking contact users

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -3,12 +3,18 @@ class Block < ApplicationRecord
   belongs_to :blocked, class_name: "User"
 
   validates :blocked_id, uniqueness: { scope: :blocker_id }
-  validate :cannot_block_self
+  validate :cannot_block_self, :cannot_block_contact, on: :create
 
   private
     def cannot_block_self
       return unless blocker_id == blocked_id
 
       errors.add(:blocked, :cannot_block_self, message: "に自分自身は指定できません。")
+    end
+
+    def cannot_block_contact
+      return unless blocker.contacts.exists?(contact_user_id: blocked_id)
+
+      errors.add(:blocked, :cannot_block_contact, message: "は登録されているためブロックできません。")
     end
 end

--- a/debride-whitelist.txt
+++ b/debride-whitelist.txt
@@ -38,3 +38,4 @@ suggestions
 reverse_contacts
 blocker
 cannot_add_blocked_user
+cannot_block_contact


### PR DESCRIPTION
### Summary

Add validation to prevent users from blocking users they have registered as contacts. This ensures data integrity and prevents contradictory user relationships within the contact and blocking system.

### Changes

- Add `cannot_block_contact` validation method to Block model
- Prevent blocking users that are registered as contacts 
- Limit validation to `:create` action only for performance optimization
- Update debride-whitelist.txt to include the new validation method
- Implement consistent validation pattern with Contact model

### Testing

- RuboCop validation passed with no offenses
- Debride check completed with 0 suspect lines of code
- Bruno API testing confirmed proper validation error responses when attempting to block contact users
<img width="2248" height="1772" alt="screen-shot-649" src="https://github.com/user-attachments/assets/eba65b02-19a6-4c87-8311-55f5da4cbf87" />


### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.