### PR TITLE
fix: correct block validation error message text

### DIFF
--- a/config/locales/active_record.ja.yml
+++ b/config/locales/active_record.ja.yml
@@ -20,7 +20,7 @@ ja:
         block:
           attributes:
             blocked_id:
-              taken: "はすでに登録されています。"
+              taken: "はすでにブロックされています。"
     attributes:
       user:
         current_password: "現在のパスワード"


### PR DESCRIPTION
This pull request fixes the validation error message for block functionality to properly reflect the blocking action instead of showing a generic registration message.

## Changes
- Updated `config/locales/active_record.ja.yml` to change the block validation error message from "はすでに登録されています。" (already registered) to "はすでにブロックされています。" (already blocked)
- Ensures the error message accurately represents the blocking functionality context

## Testing
- Verified the Japanese error message text change in the locale file
- Confirmed the change aligns with block validation functionality requirements

## Related Issues
N/A

## Notes
No additional information or considerations at this time.