### PR TITLE
chore: add task_groups table with user association

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,4 +491,4 @@ RUBY VERSION
    ruby 3.4.7p58
 
 BUNDLED WITH
-   2.4.10
+   2.6.9

--- a/db/migrate/20250926101930_create_task_groups.rb
+++ b/db/migrate/20250926101930_create_task_groups.rb
@@ -1,0 +1,16 @@
+class CreateTaskGroups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :task_groups do |t|
+      t.bigint :user_id, null: false
+      t.string :name, null: false
+      t.string :icon, null: false
+      t.text :note, limit: 1000
+
+      t.timestamps
+    end
+
+    add_index :task_groups, :user_id
+
+    add_foreign_key :task_groups, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_02_013500) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_101930) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_ja_0900_as_cs", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -60,6 +60,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_02_013500) do
     t.index ["user_id"], name: "index_contacts_on_user_id"
   end
 
+  create_table "task_groups", charset: "utf8mb4", collation: "utf8mb4_ja_0900_as_cs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "icon", null: false
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_task_groups_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_ja_0900_as_cs", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -91,4 +101,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_02_013500) do
   add_foreign_key "blocks", "users", column: "blocker_id"
   add_foreign_key "contacts", "users"
   add_foreign_key "contacts", "users", column: "contact_user_id"
+  add_foreign_key "task_groups", "users"
 end


### PR DESCRIPTION
### Summary

Add task_groups table to support user task organization functionality. This establishes the database foundation for task grouping features.

### Changes

- Create task_groups table with user_id foreign key constraint
- Add basic indexing on user_id following existing project patterns  
- Update database schema to reflect new table structure

### Testing

Migration successfully executed and verified table creation with proper constraints and indexing.

<img width="2126" height="858" alt="screen-shot-678" src="https://github.com/user-attachments/assets/abf48a28-091c-4621-b870-1ef4c93d3fcf" />
<img width="2086" height="402" alt="screen-shot-672" src="https://github.com/user-attachments/assets/f3139def-4eed-4a1e-9d68-ff3c3006fe33" />
<img width="2042" height="274" alt="screen-shot-673" src="https://github.com/user-attachments/assets/e546c33e-0a74-430e-919b-9e085d11838f" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.