### PR TITLE
feat: add task groups index API

### DIFF
--- a/.bruno/Collection/Auth/Change Password.bru
+++ b/.bruno/Collection/Auth/Change Password.bru
@@ -7,15 +7,11 @@ meta {
 patch {
   url: {{BASE_URL}}/{{API_VERSION}}/auth/password
   body: json
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }
 
 body:json {

--- a/.bruno/Collection/Auth/Change User Info.bru
+++ b/.bruno/Collection/Auth/Change User Info.bru
@@ -7,15 +7,11 @@ meta {
 patch {
   url: {{BASE_URL}}/{{API_VERSION}}/auth
   body: multipartForm
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }
 
 body:multipart-form {

--- a/.bruno/Collection/Auth/Delete User.bru
+++ b/.bruno/Collection/Auth/Delete User.bru
@@ -7,13 +7,9 @@ meta {
 delete {
   url: {{BASE_URL}}/{{API_VERSION}}/auth
   body: none
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }

--- a/.bruno/Collection/Auth/Sign Out.bru
+++ b/.bruno/Collection/Auth/Sign Out.bru
@@ -7,13 +7,9 @@ meta {
 delete {
   url: {{BASE_URL}}/{{API_VERSION}}/auth/sign_out
   body: none
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }

--- a/.bruno/Collection/Auth/Validate Token.bru
+++ b/.bruno/Collection/Auth/Validate Token.bru
@@ -7,9 +7,5 @@ meta {
 get {
   url: {{BASE_URL}}/{{API_VERSION}}/auth/validate_token
   body: none
-  auth: bearer
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
+  auth: inherit
 }

--- a/.bruno/Collection/Blocks/Create.bru
+++ b/.bruno/Collection/Blocks/Create.bru
@@ -7,15 +7,11 @@ meta {
 post {
   url: {{BASE_URL}}/{{API_VERSION}}/users/1/blocks
   body: json
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }
 
 body:json {

--- a/.bruno/Collection/Blocks/Destroy.bru
+++ b/.bruno/Collection/Blocks/Destroy.bru
@@ -7,13 +7,9 @@ meta {
 delete {
   url: {{BASE_URL}}/{{API_VERSION}}/blocks/1
   body: none
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }

--- a/.bruno/Collection/Blocks/Index.bru
+++ b/.bruno/Collection/Blocks/Index.bru
@@ -7,14 +7,10 @@ meta {
 get {
   url: {{BASE_URL}}/{{API_VERSION}}/users/1/blocks?page=1&limit=6
   body: none
-  auth: bearer
+  auth: inherit
 }
 
 params:query {
   page: 1
   limit: 6
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }

--- a/.bruno/Collection/Blocks/folder.bru
+++ b/.bruno/Collection/Blocks/folder.bru
@@ -1,4 +1,4 @@
 meta {
   name: Blocks
-  seq: 3
+  seq: 4
 }

--- a/.bruno/Collection/Contacts/Create.bru
+++ b/.bruno/Collection/Contacts/Create.bru
@@ -7,15 +7,11 @@ meta {
 post {
   url: {{BASE_URL}}/{{API_VERSION}}/users/1/contacts
   body: json
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }
 
 body:json {

--- a/.bruno/Collection/Contacts/Destroy.bru
+++ b/.bruno/Collection/Contacts/Destroy.bru
@@ -7,13 +7,9 @@ meta {
 delete {
   url: {{BASE_URL}}/{{API_VERSION}}/contacts/2
   body: json
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }

--- a/.bruno/Collection/Contacts/Index.bru
+++ b/.bruno/Collection/Contacts/Index.bru
@@ -7,14 +7,10 @@ meta {
 get {
   url: {{BASE_URL}}/{{API_VERSION}}/users/1/contacts?page=1&limit=6
   body: none
-  auth: bearer
+  auth: inherit
 }
 
 params:query {
   page: 1
   limit: 6
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }

--- a/.bruno/Collection/Contacts/Update.bru
+++ b/.bruno/Collection/Contacts/Update.bru
@@ -7,15 +7,11 @@ meta {
 patch {
   url: {{BASE_URL}}/{{API_VERSION}}/contacts/1
   body: json
-  auth: bearer
+  auth: inherit
 }
 
 headers {
   Origin: {{FRONTEND_ORIGIN}}
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }
 
 body:json {

--- a/.bruno/Collection/Contacts/folder.bru
+++ b/.bruno/Collection/Contacts/folder.bru
@@ -1,4 +1,4 @@
 meta {
   name: Contacts
-  seq: 4
+  seq: 5
 }

--- a/.bruno/Collection/TaskGroups/Index.bru
+++ b/.bruno/Collection/TaskGroups/Index.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Index
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{BASE_URL}}/{{API_VERSION}}/task_groups
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+}

--- a/.bruno/Collection/TaskGroups/folder.bru
+++ b/.bruno/Collection/TaskGroups/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: TaskGroups
+  seq: 6
+}
+
+auth {
+  mode: inherit
+}

--- a/.bruno/Collection/Users/Search.bru
+++ b/.bruno/Collection/Users/Search.bru
@@ -7,11 +7,7 @@ meta {
 get {
   url: {{BASE_URL}}/{{API_VERSION}}/users/search
   body: json
-  auth: bearer
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
+  auth: inherit
 }
 
 body:json {

--- a/.bruno/Collection/Users/Show.bru
+++ b/.bruno/Collection/Users/Show.bru
@@ -7,9 +7,5 @@ meta {
 get {
   url: {{BASE_URL}}/{{API_VERSION}}/users/2
   body: none
-  auth: bearer
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
+  auth: inherit
 }

--- a/.bruno/Collection/Users/Suggestions.bru
+++ b/.bruno/Collection/Users/Suggestions.bru
@@ -7,16 +7,12 @@ meta {
 get {
   url: {{BASE_URL}}/{{API_VERSION}}/users/suggestions?page=1&limit=6
   body: none
-  auth: bearer
+  auth: inherit
 }
 
 params:query {
   page: 1
   limit: 6
-}
-
-auth:bearer {
-  token: {{BEARER_TOKEN}}
 }
 
 settings {

--- a/.bruno/Collection/Users/folder.bru
+++ b/.bruno/Collection/Users/folder.bru
@@ -1,4 +1,4 @@
 meta {
   name: Users
-  seq: 5
+  seq: 3
 }

--- a/.bruno/Collection/collection.bru
+++ b/.bruno/Collection/collection.bru
@@ -1,0 +1,7 @@
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{BEARER_TOKEN}}
+}

--- a/app/controllers/api/v1/task_groups_controller.rb
+++ b/app/controllers/api/v1/task_groups_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class TaskGroupsController < ApplicationController
+      def index
+        task_groups = current_api_v1_user.task_groups.order(created_at: :desc)
+
+        render json: TaskGroupResource.new(task_groups), status: :ok
+      end
+    end
+  end
+end

--- a/app/resources/task_group_resource.rb
+++ b/app/resources/task_group_resource.rb
@@ -1,0 +1,5 @@
+class TaskGroupResource < ApplicationResource
+  root_key :task_group, :task_groups
+
+  attributes :id, :name, :icon, :note
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
 
           resources :blocks, only: %i[index create destroy]
         end
+
+        resources :task_groups, only: %i[index]
       end
     end
   end


### PR DESCRIPTION
### Summary

Add TaskGroups index API endpoint to allow users to retrieve their task groups list. This implementation provides a simple listing functionality without pagination.

### Changes

- Add `TaskGroupsController#index` action that retrieves authenticated user's task groups ordered by creation date
- Add `TaskGroupResource` for JSON serialization with proper root keys (`task_group`/`task_groups`)
- Add `/api/v1/task_groups` index route to routing configuration
- Add Bruno API test collection for TaskGroups endpoint validation
- Update existing Bruno collection files for consistency

### Testing

- All RuboCop style checks pass with no violations
- Debride dead code analysis shows 0 suspect LOC
- Bruno test collection added to validate API functionality
- Manual testing confirmed proper JSON response format with correct root keys

<img width="2248" height="1760" alt="screen-shot-674" src="https://github.com/user-attachments/assets/0e749f4d-462c-486f-b171-27438adf820d" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.