### PR TITLE
feat: add task groups show endpoint

### DIFF
--- a/.bruno/Collection/TaskGroups/Show.bru
+++ b/.bruno/Collection/TaskGroups/Show.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Show
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{BASE_URL}}/{{API_VERSION}}/task_groups/1
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+}

--- a/app/controllers/api/v1/task_groups_controller.rb
+++ b/app/controllers/api/v1/task_groups_controller.rb
@@ -6,6 +6,12 @@ module Api
 
         render json: TaskGroupResource.new(task_groups), status: :ok
       end
+
+      def show
+        task_group = current_api_v1_user.task_groups.find(params[:id])
+
+        render json: TaskGroupResource.new(task_group), status: :ok
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
           resources :blocks, only: %i[index create destroy]
         end
 
-        resources :task_groups, only: %i[index]
+        resources :task_groups, only: %i[index show]
       end
     end
   end


### PR DESCRIPTION
### Summary

Add show endpoint to TaskGroups API to retrieve individual task group details.

### Changes

- Add `show` action to `task_groups` routes (config/routes.rb)
- Implement `TaskGroupsController#show` method
- Add Bruno API test file for show endpoint (.bruno/Collection/TaskGroups/Show.bru)

### Testing

- Manual testing confirmed through Bruno API client
- RuboCop: No offenses detected
- Debride: No dead code detected

<img width="2248" height="1760" alt="screen-shot-675" src="https://github.com/user-attachments/assets/b4adca1f-df03-4ea1-a669-ad86391d5471" />

### Related Issues (Optional)

N/A

### Notes (Optional)

Users can only access their own task groups through `current_api_v1_user` scope, ensuring proper authorization.